### PR TITLE
Fixing Tutorial 02

### DIFF
--- a/tutorials/developers/tutorial_02/tutorial_02.cpp
+++ b/tutorials/developers/tutorial_02/tutorial_02.cpp
@@ -10,26 +10,18 @@
 
 #include <string.h>
 #include <Halide.h>
-#include "halide_image_io.h"
 
-/* Halide code.
-Func blurxy(Func input, Func blur_y) {
-    Func blur_x;
-    Var x, y, xi, yi;
+/**
+  The goal of this tutorial is to implement in Tiramisu a code that is
+  equivalent to the following
 
-    // The algorithm - no storage or order
-    blur_x(x, y) = (input(x-1, y) + input(x, y) + input(x+1, y))/3;
-    blur_y(x, y) = (blur_x(x, y-1) + blur_x(x, y) + blur_x(x, y+1))/3;
-
-    // The schedule - defines order, locality; implies storage
-    blur_y.tile(x, y, xi, yi, 256, 32)
-        .vectorize(xi, 8).parallel(y);
-    blur_x.compute_at(blur_y, x).vectorize(x, 8);
-  }
+  for (int i = 0; i < 10; i++)
+    for (int j = 0; j < 20; j++)
+      output[i, j] = input[i, j] + i + 2;
 */
 
-#define SIZE0 8
-#define SIZE1 16
+#define NN 10
+#define MM 20
 
 using namespace tiramisu;
 
@@ -39,37 +31,26 @@ int main(int argc, char **argv)
     global::set_default_tiramisu_options();
 
 
+
     // -------------------------------------------------------
     // Layer I
     // -------------------------------------------------------
 
-    /*
-     * Declare a function blurxy.
-     * Declare two arguments (tiramisu buffers) for the function: b_input and b_blury
-     * Declare an invariant for the function.
-     */
-    function blurxy("blurxy");
+    // Declare the function tut_02.
+    function tut_02("tut_02");
 
-    constant p0("N", expr((int32_t) SIZE0), p_int32, true, NULL, 0, &blurxy);
-    constant p1("M", expr((int32_t) SIZE1), p_int32, true, NULL, 0, &blurxy);
+    constant N_const("N", expr((int32_t) NN), p_int32, true, NULL, 0, &tut_02);
+    constant M_const("M", expr((int32_t) MM), p_int32, true, NULL, 0, &tut_02);
+
+    // Declare variables
+    var i("i"), j("j");
 
     // Declare a wrapper around the input.
-    computation c_input("[N]->{c_input[i,j]: 0<=i<N and 0<=j<N}", expr(), false, p_uint8, &blurxy);
+    computation input("[N, M]->{input[i,j]: 0<=i<N and 0<=j<M}", expr(), false, p_uint8, &tut_02);
 
-    var i("i"), j("j"), i0("i0"), i1("i1"), j0("j0"), j1("j1");
-
-    // Declare the computations c_blurx and c_blury.
-    expr e1 = (c_input(i - 1, j) +
-               c_input(i    , j) +
-               c_input(i + 1, j)) / ((uint8_t) 3);
-
-    computation c_blurx("[N,M]->{c_blurx[i,j]: 0<i<N and 0<j<M}", e1, true, p_uint8, &blurxy);
-
-    expr e2 = (c_blurx(i, j - 1) +
-               c_blurx(i, j) +
-               c_blurx(i, j + 1)) / ((uint8_t) 3);
-
-    computation c_blury("[N,M]->{c_blury[i,j]: 1<i<N-1 and 1<j<M-1}", e2, true, p_uint8, &blurxy);
+    // Declare expression and output computation.
+    expr e = input(i, j) + cast(p_uint8, i)+ (uint8_t)4;
+    computation output("[N, M]->{output[i,j]: 0<=i<N and 0<=j<M}", e, true, p_uint8, &tut_02);
 
 
 
@@ -77,10 +58,10 @@ int main(int argc, char **argv)
     // Layer II
     // -------------------------------------------------------
 
-    // Set the schedule of each computation.
-    c_blurx.tile(i, j, 2, 2, i0, j0, i1, j1);
-    c_blurx.tag_parallel_level(i0);
-    c_blury.after(c_blurx, computation::root);
+    // Set the schedule of the computation.
+    var i0("i0"), i1("i1"), j0("j0"), j1("j1");
+    output.tile(i, j, 2, 2, i0, j0, i1, j1);
+    output.tag_parallel_level(i0);
 
 
 
@@ -88,14 +69,12 @@ int main(int argc, char **argv)
     // Layer III
     // -------------------------------------------------------
 
-    buffer b_input("b_input", {expr(SIZE0), expr(SIZE1)}, p_uint8, a_input, &blurxy);
-    buffer b_blury("b_blury", {expr(SIZE0), expr(SIZE1)}, p_uint8, a_output, &blurxy);
-    buffer b_blurx("b_blurx", {expr(SIZE0), expr(SIZE1)}, p_uint8, a_temporary, &blurxy);
+    buffer b_input("b_input", {expr(NN), expr(MM)}, p_uint8, a_input, &tut_02);
+    buffer b_output("b_output", {expr(NN), expr(MM)}, p_uint8, a_output, &tut_02);
 
     // Map the computations to a buffer.
-    c_input.set_access("{c_input[i,j]->b_input[i,j]}");
-    c_blurx.set_access("{c_blurx[i,j]->b_blurx[i,j]}");
-    c_blury.set_access("{c_blury[i,j]->b_blury[i,j]}");
+    input.set_access("{input[i,j]->b_input[i,j]}");
+    output.set_access("{output[i,j]->b_output[i,j]}");
 
 
 
@@ -103,20 +82,20 @@ int main(int argc, char **argv)
     // Code Generation
     // -------------------------------------------------------
 
-    // Set the arguments to blurxy
-    blurxy.set_arguments({&b_input, &b_blury});
+    // Set the arguments to tut_02
+    tut_02.set_arguments({&b_input, &b_output});
     // Generate code
-    blurxy.gen_time_space_domain();
-    blurxy.gen_isl_ast();
-    blurxy.gen_halide_stmt();
-    blurxy.gen_halide_obj("build/generated_fct_developers_tutorial_02.o");
+    tut_02.gen_time_space_domain();
+    tut_02.gen_isl_ast();
+    tut_02.gen_halide_stmt();
+    tut_02.gen_halide_obj("build/generated_fct_developers_tutorial_02.o");
 
     // Some debugging
-    blurxy.dump_iteration_domain();
-    blurxy.dump_halide_stmt();
+    tut_02.dump_iteration_domain();
+    tut_02.dump_halide_stmt();
 
-    // Dump all the fields of the blurxy class.
-    blurxy.dump(true);
+    // Dump all the fields of the tut_02 class.
+    tut_02.dump(true);
 
     return 0;
 }

--- a/tutorials/developers/tutorial_02/wrapper_tutorial_02.cpp
+++ b/tutorials/developers/tutorial_02/wrapper_tutorial_02.cpp
@@ -1,38 +1,44 @@
 #include "Halide.h"
 #include "wrapper_tutorial_02.h"
-#include "halide_image_io.h"
 #include "tiramisu/utils.h"
 #include <cstdlib>
 #include <iostream>
 
 
-#define NN 8 
-#define MM 16
-#define Val 225
+#define NN 10 
+#define MM 20
 
 
 int main(int, char **)
 {
-    
-    Halide::Buffer<uint8_t> input(NN,MM);
+    // Index convention of Halide is the opposite of C and Tiramisu. Thus we
+    // need to flip the indices when initializing and accessing Halide buffers.
+    // Following buffer will have shape input[NN][MM] when passed to Tiramisu.
+    Halide::Buffer<uint8_t> input(MM, NN);
 
-    init_buffer(input, (uint8_t)Val);
+    init_buffer(input, (uint8_t)3);
     
     // Uncomment the following two lines if you want to view the input table
-    // std::cout << "Array (before Blurxy)" << std::endl;
+    // std::cout << "Array (before tut_02)" << std::endl;
     // print_buffer(input); 
 
-    Halide::Buffer<uint8_t> output_buf(NN,MM);
+    Halide::Buffer<uint8_t> output(MM, NN);
 
-    // The blurxy takes a halide_buffer_t * as argument, when "input"
-    // is passed, its buffer is actually extracted and passed
-    // to the function (c++ operator overloading).
-
-    blurxy(input.raw_buffer(), output_buf.raw_buffer());
+    tut_02(input.raw_buffer(), output.raw_buffer());
 
     // Uncomment the following two lines if you want to view the output table
-    // std::cout << "Array (after Blurxy)" << std::endl;
+    // std::cout << "Array (after tut_02)" << std::endl;
     // print_buffer(output_buf); 
+
+    Halide::Buffer<uint8_t> expected(MM, NN);
+    for (int i = 0; i < NN; i++) {
+        for (int j = 0; j < MM; j++) {
+            // Note the indices are flipped
+            expected(j, i) = input(j, i) + i + 4;
+        }
+    }
+
+    compare_buffers("tutorial 02", output, expected);
 
     return 0;
 }

--- a/tutorials/developers/tutorial_02/wrapper_tutorial_02.cpp
+++ b/tutorials/developers/tutorial_02/wrapper_tutorial_02.cpp
@@ -28,7 +28,7 @@ int main(int, char **)
 
     // Uncomment the following two lines if you want to view the output table
     // std::cout << "Array (after tut_02)" << std::endl;
-    // print_buffer(output_buf); 
+    // print_buffer(output); 
 
     Halide::Buffer<uint8_t> expected(MM, NN);
     for (int i = 0; i < NN; i++) {

--- a/tutorials/developers/tutorial_02/wrapper_tutorial_02.h
+++ b/tutorials/developers/tutorial_02/wrapper_tutorial_02.h
@@ -7,10 +7,7 @@
 extern "C" {
 #endif
 
-int blurxy(halide_buffer_t *_b_input_buffer, halide_buffer_t *_b_blury_buffer);
-int blurxy_argv(void **args);
-// Result is never null and points to constant static data
-const struct halide_filter_metadata_t *blurxy_metadata();
+int tut_02(halide_buffer_t *_b_input_buffer, halide_buffer_t *_b_output_buffer);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Align with https://github.com/Tiramisu-Compiler/tiramisu/issues/47, replacing tutorial 02 with a simpler tutorial that shows the index convention difference between Halide and Tiramisu.

Tutorial passes.