### PR TITLE
Add gpu_tile overloads

### DIFF
--- a/include/tiramisu/core.h
+++ b/include/tiramisu/core.h
@@ -3226,10 +3226,19 @@ public:
       * \p L0 and \p L1 should be two consecutive loop levels
       * (i.e., \p L0 = \p L1 + 1) and they should satisfy
       * \p L0 > \p L1.
+      *
+      * \p L0_outer, \p L1_outer, \p L0_inner, \p L1_inner
+      * are the names of the new dimensions created after tiling.
       */
     // @{
     void gpu_tile(tiramisu::var L0, tiramisu::var L1, int sizeX, int sizeY);
+    void gpu_tile(tiramisu::var L0, tiramisu::var L1, int sizeX, int sizeY,
+                  tiramisu::var L0_outer, tiramisu::var L1_outer,
+                  tiramisu::var L0_inner, tiramisu::var L1_inner);
     void gpu_tile(tiramisu::var L0, tiramisu::var L1, tiramisu::var L2, int sizeX, int sizeY, int sizeZ);
+    void gpu_tile(tiramisu::var L0, tiramisu::var L1, tiramisu::var L2, int sizeX, int sizeY, int sizeZ,
+                  tiramisu::var L0_outer, tiramisu::var L1_outer, tiramisu::var L2_outer,
+                  tiramisu::var L0_inner, tiramisu::var L1_inner, tiramisu::var L2_inner);
     // @}
 
     /**

--- a/src/tiramisu_core.cpp
+++ b/src/tiramisu_core.cpp
@@ -3419,6 +3419,14 @@ void computation::gpu_tile(tiramisu::var L0_var, tiramisu::var L1_var, int sizeX
     this->tag_gpu_thread_level(L0 + 2, L1 + 2);
 }
 
+void computation::gpu_tile(tiramisu::var L0, tiramisu::var L1, int sizeX, int sizeY,
+                           tiramisu::var L0_outer, tiramisu::var L1_outer,
+                           tiramisu::var L0_inner, tiramisu::var L1_inner)
+{
+    this->tile(L0, L1, sizeX, sizeY, L0_outer, L1_outer, L0_inner, L1_inner);
+    this->tag_gpu_level(L0_outer, L1_outer, L0_inner, L1_inner);
+}
+
 void computation::gpu_tile(tiramisu::var L0_var, tiramisu::var L1_var, tiramisu::var L2_var, int sizeX, int sizeY, int sizeZ)
 {
     assert(L0_var.get_name().length() > 0);
@@ -3447,6 +3455,15 @@ void computation::gpu_tile(tiramisu::var L0_var, tiramisu::var L1_var, tiramisu:
     this->tile(L0, L1, L2, sizeX, sizeY, sizeZ);
     this->tag_gpu_block_level(L0, L1, L2);
     this->tag_gpu_thread_level(L0 + 3, L1 + 3, L2 + 3);
+}
+
+void computation::gpu_tile(tiramisu::var L0, tiramisu::var L1, tiramisu::var L2,
+                           int sizeX, int sizeY, int sizeZ,
+                           tiramisu::var L0_outer, tiramisu::var L1_outer, tiramisu::var L2_outer,
+                           tiramisu::var L0_inner, tiramisu::var L1_inner, tiramisu::var L2_inner)
+{
+    this->tile(L0, L1, L2, sizeX, sizeY, sizeZ, L0_outer, L1_outer, L2_outer, L0_inner, L1_inner, L2_inner);
+    this->tag_gpu_level(L0_outer, L1_outer, L2_outer, L0_inner, L1_inner, L2_inner);
 }
 
 void computation::assert_names_not_assigned(


### PR DESCRIPTION
Fixes https://github.com/Tiramisu-Compiler/tiramisu/issues/60. Note that these are just wrappers and argument validity is not checked since the check is done by `tile` and `tag_gpu_level` functions.