### PR TITLE
Fix README and submodule installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ This section provides a short description of how to build Tiramisu.  A more deta
 
 2) Get and install Tiramisu submodules (ISL, LLVM and Halide).  This step may take between few minutes to few hours (downloading and compiling LLVM is time consuming).
 
-        ./utils/scripts/install_submodules.sh <TIRAMISU_ROOT_DIR>
+        ./utils/scripts/install_submodules.sh
 
 3) Optional: configure the tiramisu build by editing `configure.cmake`.  Needed only if you want to generate MPI or GPU code, or if you want to run the BLAS benchmarks.  A description of what each variable is and how it should be set is provided in comments in `configure.cmake`.
 
-    - To use the GPU backend, set `USE_GPU` to `true`.  If the CUDA library is not found automatically while building Tiramisu, the user will be prompt to provide the path to the CUDA library.
+    - To use the GPU backend, set `USE_GPU` to `true`. Requires CUDA to be installed on the system.
     - To use the distributed backend, set `USE_MPI` to `true`.  If the MPI library is not found automatically, set the following variables: MPI_INCLUDE_DIR, MPI_LIB_DIR, and MPI_LIB_FLAGS.
 
 4) Build the main Tiramisu library

--- a/utils/scripts/install_submodules.sh
+++ b/utils/scripts/install_submodules.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -eq 0 ]; then
+    PROJECT_SRC_DIR=$PWD
+elif [ "$#" -eq 1 ]; then
+    PROJECT_SRC_DIR=$1
+else
 	echo "Usage: install_submodules.sh <TIRAMISU_ROOT_PATH>"
 	exit 1
 fi
 
-PROJECT_SRC_DIR=$1
 CMAKE=cmake
 CORES=8
 


### PR DESCRIPTION
Changing submodule installation script so that if no argument is given, it assumes tiramisu root folder is the current folder.