### PR TITLE
Error function fix

### DIFF
--- a/include/tiramisu/debug.h
+++ b/include/tiramisu/debug.h
@@ -21,8 +21,6 @@ void str_dump(const std::string &str, const char *str2);
 void str_dump(const char *str, const char *str2);
 void print_indentation();
 
-void error(const std::string &str, bool exit);
-
 extern int tiramisu_indentation;
 
 } // namespace tiramisu
@@ -86,5 +84,14 @@ extern int tiramisu_indentation;
   * Useful to indent the text printed by IF_DEBUG.
   */
 #define DEBUG_INDENT(x) {tiramisu::tiramisu_indentation = tiramisu::tiramisu_indentation + x;}
+
+#define ERROR(message, exit_program) {                      \
+    std::cerr << "Error in " << __FILE__ << ":"             \
+              << __LINE__ << " - " << message << std::endl; \
+    if (exit_program)                                       \
+    {                                                       \
+        exit(1);                                            \
+    }                                                       \
+}
 
 #endif

--- a/include/tiramisu/expr.h
+++ b/include/tiramisu/expr.h
@@ -349,7 +349,7 @@ public:
         }
         else
         {
-            tiramisu::error("Type of operator is not o_access, o_call, o_address_of, o_buffer, or o_lin_index.", true);
+            ERROR("Type of operator is not o_access, o_call, o_address_of, o_buffer, or o_lin_index.", true);
         }
 
         this->name = name;
@@ -623,7 +623,7 @@ public:
         }
         else
         {
-            tiramisu::error("Calling get_int_val() on a non integer expression.", true);
+            ERROR("Calling get_int_val() on a non integer expression.", true);
         }
 
         return result;
@@ -645,7 +645,7 @@ public:
         }
         else
         {
-            tiramisu::error("Calling get_double_val() on a non double expression.", true);
+            ERROR("Calling get_double_val() on a non double expression.", true);
         }
 
         return result;
@@ -1136,7 +1136,7 @@ public:
                         std::cout << "Sync object" << std::endl;
                         break;
                     default:
-                        tiramisu::error("Expression type not supported.", true);
+                        ERROR("Expression type not supported.", true);
                     }
                 }
             }
@@ -1276,7 +1276,7 @@ public:
                     case tiramisu::o_free:
                         return *this;
                     default:
-                        tiramisu::error("Simplifying an unsupported tiramisu expression.", 1);
+                        ERROR("Simplifying an unsupported tiramisu expression.", 1);
                     }
                     break;
                 }
@@ -1289,7 +1289,7 @@ public:
                     return *this;
                 }
                 default:
-                    tiramisu::error("Expression type not supported.", true);
+                    ERROR("Expression type not supported.", true);
             }
         }
 
@@ -1527,7 +1527,7 @@ public:
                         str +=  "free(" + this->get_name() + ")";
                         break;
                     default:
-                        tiramisu::error("Dumping an unsupported tiramisu expression.", 1);
+                        ERROR("Dumping an unsupported tiramisu expression.", 1);
                     }
                     break;
                 }
@@ -1586,7 +1586,7 @@ public:
                     break;
                 }
                 default:
-                    tiramisu::error("Expression type not supported.", true);
+                    ERROR("Expression type not supported.", true);
                 }
             }
 

--- a/include/tiramisu/utils.h
+++ b/include/tiramisu/utils.h
@@ -69,7 +69,7 @@ inline void copy_buffer(const Halide::Buffer<T> &from, Halide::Buffer<T> &to)
     if ((from.dimensions() > to.dimensions()) || (from.channels() > to.channels()) ||
         (from.height() > to.height()) || (from.width() > to.width()))
     {
-        tiramisu::error("'from' has bigger dimension size than 'to'. 'from' size: " +
+        ERROR("'from' has bigger dimension size than 'to'. 'from' size: " +
                         std::to_string(from.dimensions()) + ", 'to' size: " +
                         std::to_string(to.dimensions()) + "\n", true);
     }
@@ -95,14 +95,14 @@ inline void compare_buffers_approximately(const std::string &test, const Halide:
         (result.height() != expected.height()) ||
         (result.width() != expected.width()))
     {
-        tiramisu::error("result has different dimension size from expected\n", true);
+        ERROR("result has different dimension size from expected\n", true);
     }
 
     for (int z = 0; z < result.channels(); z++) {
         for (int y = 0; y < result.height(); y++) {
             for (int x = 0; x < result.width(); x++) {
                 if (result(x, y, z) - expected(x, y, z) > 0.1) {
-                    tiramisu::error("\033[1;31mTest " + test + " failed. At (" + std::to_string(x) +
+                    ERROR("\033[1;31mTest " + test + " failed. At (" + std::to_string(x) +
                                     ", " + std::to_string(y) + ", " + std::to_string(z) + "), expected: " +
                                     std::to_string(expected(x, y, z)) + ", got: " +
                                     std::to_string(result(x, y, z)) + ".\033[0m\n", false);
@@ -130,7 +130,7 @@ inline void compare_4D_buffers(const std::string &test, const Halide::Buffer<T> 
                         << std::endl;
 #endif
                     if (result(x, y, z, n) != expected(x, y, z, n)) {
-                        tiramisu::error("\033[1;31mTest " + test + " failed. At (" + std::to_string(x) +
+                        ERROR("\033[1;31mTest " + test + " failed. At (" + std::to_string(x) +
                                         ", " + std::to_string(y) + ", " + std::to_string(z) + ", " + std::to_string(n)+ "), expected: " +
                                         std::to_string(expected(x, y, z, n)) + ", got: " +
                                         std::to_string(result(x, y, z, n)) + ".\033[0m\n", false);
@@ -152,14 +152,14 @@ inline void compare_buffers(const std::string &test, const Halide::Buffer<T> &re
         (result.height() != expected.height()) ||
         (result.width() != expected.width()))
     {
-        tiramisu::error("result has different dimension size from expected\n", true);
+        ERROR("result has different dimension size from expected\n", true);
     }*/
 
     for (int z = 0; z < result.channels(); z++) {
         for (int y = 0; y < result.height(); y++) {
             for (int x = 0; x < result.width(); x++) {
                 if (result(x, y, z) != expected(x, y, z)) {
-                    tiramisu::error("\033[1;31mTest " + test + " failed. At (" + std::to_string(x) +
+                    ERROR("\033[1;31mTest " + test + " failed. At (" + std::to_string(x) +
                                     ", " + std::to_string(y) + ", " + std::to_string(z) + "), expected: " +
                                     std::to_string(expected(x, y, z)) + ", got: " +
                                     std::to_string(result(x, y, z)) + ".\033[0m\n", true);
@@ -179,9 +179,7 @@ inline void print_test_results(const std::string &test, bool success)
     if (success == true)
         tiramisu::str_dump("\033[1;32mTest " + test + " succeeded.\033[0m\n");
     else
-        tiramisu::error("\033[1;31mTest " + test + " failed.\033[0m\n", false);
-
-
+        ERROR("\033[1;31mTest " + test + " failed.\033[0m\n", false);
 }
 
 

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -1690,7 +1690,9 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         auto result = exec(command.str());
 
         if (result.fail())
-            tiramisu::error("Failed to compile the CPU object for the GPU code.", false);
+        {
+            ERROR("Failed to compile the CPU object for the GPU code.", false);
+        }
 
         DEBUG_INDENT(-4);
 
@@ -1717,7 +1719,9 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         auto result = exec(command.str());
 
         if (result.fail())
-            tiramisu::error("Failed to compile the GPU object for the GPU code.", false);
+        {
+            ERROR("Failed to compile the GPU object for the GPU code.", false);
+        }
 
         DEBUG_INDENT(-4);
 
@@ -1736,7 +1740,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         if (!getenv("CUDA_NO_OVERWRITE")) {
             code_file.open(filename, fstream::out | fstream::trunc);
             if (code_file.fail()) {
-                tiramisu::error("Failed to open file " + filename + " for writing. Cannot compile GPU code.", false);
+                ERROR("Failed to open file " + filename + " for writing. Cannot compile GPU code.", false);
                 return false;
             }
             DEBUG(3, cout << "Opened file " << filename << " for writing.");
@@ -1744,7 +1748,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
             code_file << code;
             code_file.flush();
             if (code_file.fail()) {
-                tiramisu::error("Failed to write to file " + filename + ". Cannot compile GPU code.", false);
+                ERROR("Failed to write to file " + filename + ". Cannot compile GPU code.", false);
                 return false;
             }
         }

--- a/src/tiramisu_codegen_from_halide.cpp
+++ b/src/tiramisu_codegen_from_halide.cpp
@@ -71,7 +71,7 @@ tiramisu::primitive_t halide_type_to_tiramisu_type(Type type)
         }
         else
         {
-            tiramisu::error("Floats other than 32 and 64 bits are not suppored in Tiramisu.", true);
+            ERROR("Floats other than 32 and 64 bits are not suppored in Tiramisu.", true);
         }
     }
     else if (type.is_bool())
@@ -80,7 +80,7 @@ tiramisu::primitive_t halide_type_to_tiramisu_type(Type type)
     }
     else
     {
-        tiramisu::error("Halide type cannot be translated to Tiramisu type.", true);
+        ERROR("Halide type cannot be translated to Tiramisu type.", true);
     }
     return tiramisu::p_none;
 }
@@ -117,7 +117,7 @@ private:
 
     void error() const
     {
-        tiramisu::error("Can't convert to tiramisu expr.", true);
+        ERROR("Can't convert to tiramisu expr.", true);
     }
 
     void push_loop_dim(const For *op)

--- a/src/tiramisu_codegen_halide.cpp
+++ b/src/tiramisu_codegen_halide.cpp
@@ -270,7 +270,7 @@ bool access_has_id(const tiramisu::expr &exp)
                          access_has_id(exp.get_operand(2));
                 break;
             default:
-                tiramisu::error("Checking an unsupported tiramisu expression for whether it has an ID.", 1);
+                ERROR("Checking an unsupported tiramisu expression for whether it has an ID.", 1);
         }
     }
 
@@ -363,7 +363,7 @@ bool access_is_affine(const tiramisu::expr &exp)
                 }
                 break;
             default:
-                tiramisu::error("Unsupported tiramisu expression passed to access_is_affine().", 1);
+                ERROR("Unsupported tiramisu expression passed to access_is_affine().", 1);
         }
     }
 
@@ -488,7 +488,7 @@ isl_constraint *generator::get_constraint_for_access(int access_dimension,
         }
         else
         {
-            tiramisu::error ("Currently only Add, Sub, Minus, and Mul operations for accesses are supported for now.", true);
+            ERROR("Currently only Add, Sub, Minus, and Mul operations for accesses are supported for now.", true);
         }
     }
 
@@ -748,7 +748,7 @@ void generator::traverse_expr_and_extract_accesses(const tiramisu::function *fct
                 // They do not have any access.
                 break;
             default:
-                tiramisu::error("Extracting access function from an unsupported tiramisu expression.", 1);
+                ERROR("Extracting access function from an unsupported tiramisu expression.", 1);
         }
     }
 
@@ -884,7 +884,7 @@ tiramisu::expr traverse_expr_and_replace_non_affine_accesses(tiramisu::computati
                 output_expr = exp;
                 break;
             default:
-                tiramisu::error("Unsupported tiramisu expression passed to traverse_expr_and_replace_non_affine_accesses().",
+                ERROR("Unsupported tiramisu expression passed to traverse_expr_and_replace_non_affine_accesses().",
                                 1);
         }
     }
@@ -976,7 +976,7 @@ tiramisu::expr tiramisu_expr_from_isl_ast_expr(isl_ast_expr *isl_expr)
                 break;
             case isl_ast_op_and_then:
                 result = tiramisu::expr(tiramisu::o_logical_and, op0, op1);
-                tiramisu::error("isl_ast_op_and_then operator found in the AST. This operator is not well supported.",
+                ERROR("isl_ast_op_and_then operator found in the AST. This operator is not well supported.",
                                 0);
                 break;
             case isl_ast_op_or:
@@ -984,7 +984,7 @@ tiramisu::expr tiramisu_expr_from_isl_ast_expr(isl_ast_expr *isl_expr)
                 break;
             case isl_ast_op_or_else:
                 result = tiramisu::expr(tiramisu::o_logical_or, op0, op1);
-                tiramisu::error("isl_ast_op_or_then operator found in the AST. This operator is not well supported.",
+                ERROR("isl_ast_op_or_then operator found in the AST. This operator is not well supported.",
                                 0);
                 break;
             case isl_ast_op_max:
@@ -1041,7 +1041,7 @@ tiramisu::expr tiramisu_expr_from_isl_ast_expr(isl_ast_expr *isl_expr)
                 tiramisu::str_dump("Transforming the following expression",
                                    (const char *)isl_ast_expr_to_C_str(isl_expr));
                 tiramisu::str_dump("\n");
-                tiramisu::error("Translating an unsupported ISL expression into a Tiramisu expression.", 1);
+                ERROR("Translating an unsupported ISL expression into a Tiramisu expression.", 1);
         }
     }
     else
@@ -1049,7 +1049,7 @@ tiramisu::expr tiramisu_expr_from_isl_ast_expr(isl_ast_expr *isl_expr)
         tiramisu::str_dump("Transforming the following expression",
                            (const char *)isl_ast_expr_to_C_str(isl_expr));
         tiramisu::str_dump("\n");
-        tiramisu::error("Translating an unsupported ISL expression into a Tiramisu expression.", 1);
+        ERROR("Translating an unsupported ISL expression into a Tiramisu expression.", 1);
     }
 
     DEBUG_INDENT(-4);
@@ -1175,7 +1175,7 @@ tiramisu::expr replace_original_indices_with_transformed_indices(tiramisu::expr 
                 output_expr = exp;
                 break;
             default:
-                tiramisu::error("Unsupported tiramisu expression passed to replace_original_indices_with_transformed_indices().", 1);
+                ERROR("Unsupported tiramisu expression passed to replace_original_indices_with_transformed_indices().", 1);
         }
     }
 
@@ -1356,7 +1356,7 @@ isl_ast_node *generator::stmt_code_generator(isl_ast_node *node, isl_ast_build *
                         {
                             tiramisu::str_dump("This is computation " + comp->get_name() +"\n");
                             // TODO better error message
-                            tiramisu::error("An access function should be provided for computation " + comp->get_name() + "'s #" + std::to_string(i) + " access before generating code.", true);
+                            ERROR("An access function should be provided for computation " + comp->get_name() + "'s #" + std::to_string(i) + " access before generating code.", true);
                         }
                     }
                 }
@@ -1444,7 +1444,7 @@ Halide::Expr halide_expr_from_isl_ast_expr_temp(isl_ast_expr *isl_expr)
                 break;
             case isl_ast_op_and_then:
                 result = Halide::Internal::And::make(op0, op1);
-                tiramisu::error("isl_ast_op_and_then operator found in the AST. This operator is not well supported.",
+                ERROR("isl_ast_op_and_then operator found in the AST. This operator is not well supported.",
                                 0);
                 break;
             case isl_ast_op_or:
@@ -1452,7 +1452,7 @@ Halide::Expr halide_expr_from_isl_ast_expr_temp(isl_ast_expr *isl_expr)
                 break;
             case isl_ast_op_or_else:
                 result = Halide::Internal::Or::make(op0, op1);
-                tiramisu::error("isl_ast_op_or_then operator found in the AST. This operator is not well supported.",
+                ERROR("isl_ast_op_or_then operator found in the AST. This operator is not well supported.",
                                 0);
                 break;
             case isl_ast_op_max:
@@ -1508,7 +1508,7 @@ Halide::Expr halide_expr_from_isl_ast_expr_temp(isl_ast_expr *isl_expr)
                 tiramisu::str_dump("Transforming the following expression",
                                    (const char *)isl_ast_expr_to_C_str(isl_expr));
                 tiramisu::str_dump("\n");
-                tiramisu::error("Translating an unsupported ISL expression in a Halide expression.", 1);
+                ERROR("Translating an unsupported ISL expression in a Halide expression.", 1);
         }
     }
     else
@@ -1516,7 +1516,7 @@ Halide::Expr halide_expr_from_isl_ast_expr_temp(isl_ast_expr *isl_expr)
         tiramisu::str_dump("Transforming the following expression",
                            (const char *)isl_ast_expr_to_C_str(isl_expr));
         tiramisu::str_dump("\n");
-        tiramisu::error("Translating an unsupported ISL expression in a Halide expression.", 1);
+        ERROR("Translating an unsupported ISL expression in a Halide expression.", 1);
     }
 
     return result;
@@ -1863,7 +1863,7 @@ tiramisu::generator::halide_stmt_from_isl_node(const tiramisu::function &fct, is
 
             isl_val *inc_val = isl_ast_expr_get_val(inc);
             if (!isl_val_is_one(inc_val)) {
-                tiramisu::error("The increment in one of the loops is not +1."
+                ERROR("The increment in one of the loops is not +1."
                                         "This is not supported by Halide", 1);
             }
             isl_val_free(inc_val);
@@ -1891,7 +1891,7 @@ tiramisu::generator::halide_stmt_from_isl_node(const tiramisu::function &fct, is
                         isl_ast_expr_get_op_arg(cond, 1),
                         isl_ast_expr_from_val(one));
             } else {
-                tiramisu::error("The for loop upper bound is not an isl_est_expr of type le or lt", 1);
+                ERROR("The for loop upper bound is not an isl_est_expr of type le or lt", 1);
             }
             assert(cond_upper_bound_isl_format != NULL);
             DEBUG(3, tiramisu::str_dump("Creating for loop init expression."));
@@ -2106,7 +2106,9 @@ tiramisu::generator::halide_stmt_from_isl_node(const tiramisu::function &fct, is
              (get_computation_annotated_in_a_node(node)->get_expr().get_op_type() == tiramisu::o_free)))
         {
             if (get_computation_annotated_in_a_node(node)->get_expr().get_op_type() == tiramisu::o_allocate)
-                tiramisu::error("Allocate node should not appear as a user ISL AST node. It should only appear with block construction (because of its scope).", true);
+            {
+                ERROR("Allocate node should not appear as a user ISL AST node. It should only appear with block construction (because of its scope).", true);
+            }
             else
             {
                 tiramisu::computation *comp = get_computation_annotated_in_a_node(node);
@@ -3006,7 +3008,7 @@ void computation::create_halide_assignment()
             }
             // Defines writing into the wait buffer when a transfer is initiated (for nonblocking operations)
             if (this->wait_argument_idx != -1) {
-                tiramisu::error("Nonblocking not currently supported", 0);
+                ERROR("Nonblocking not currently supported", 0);
                 assert((this->is_recv() || this->is_send_recv()) && "This should be a recv or one-sided operation.");
                 assert(this->wait_access_map && "A wait access map must be provided.");
                 // We treat this like another LHS access, so we'll recompute the LHS access using the req access map.
@@ -3085,7 +3087,7 @@ void computation::create_halide_assignment()
                                                                                                this->get_expr(), this);
             }
             if (this->wait_argument_idx != -1) {
-                tiramisu::error("Nonblocking not currently supported", 0);
+                ERROR("Nonblocking not currently supported", 0);
                 assert(this->is_send() && "This should be a send operation.");
                 assert(this->wait_access_map && "A request access map must be provided.");
                 // We treat this like another LHS access, so we'll recompute the LHS access using the req access map.
@@ -3374,7 +3376,7 @@ Halide::Expr generator::halide_expr_from_tiramisu_expr(const tiramisu::function 
                 DEBUG(10, tiramisu::str_dump("op type: lerp"));
                 break;
             case tiramisu::o_cond:
-                tiramisu::error("Code generation for o_cond is not supported yet.", true);
+                ERROR("Code generation for o_cond is not supported yet.", true);
                 break;
             case tiramisu::o_le:
                 result = Halide::Internal::LE::make(op0, op1, true);
@@ -3428,7 +3430,7 @@ Halide::Expr generator::halide_expr_from_tiramisu_expr(const tiramisu::function 
                 }
                 else
                 {
-                    tiramisu::error("Unsupported operation.", true);
+                    ERROR("Unsupported operation.", true);
                 }
 
                 assert(access_comp_name != NULL);
@@ -3705,11 +3707,11 @@ Halide::Expr generator::halide_expr_from_tiramisu_expr(const tiramisu::function 
             }
             case tiramisu::o_allocate:
             case tiramisu::o_free:
-                tiramisu::error("An expression of type o_allocate or o_free "
+                ERROR("An expression of type o_allocate or o_free "
                                         "should not be passed to this function", true);
                 break;
             default:
-                tiramisu::error("Translating an unsupported ISL expression into a Halide expression.", 1);
+                ERROR("Translating an unsupported ISL expression into a Halide expression.", 1);
         }
     }
     else if (tiramisu_expr.get_expr_type() == tiramisu::e_var)
@@ -3724,7 +3726,7 @@ Halide::Expr generator::halide_expr_from_tiramisu_expr(const tiramisu::function 
     {
         tiramisu::str_dump("tiramisu type of expr: ",
                            str_from_tiramisu_type_expr(tiramisu_expr.get_expr_type()).c_str());
-        tiramisu::error("\nTranslating an unsupported ISL expression in a Halide expression.", 1);
+        ERROR("\nTranslating an unsupported ISL expression in a Halide expression.", 1);
     }
 
     if (result.defined())
@@ -3878,7 +3880,7 @@ void tiramisu::generator::_update_producer_expr_name(tiramisu::expr &current_exp
                 // They do not have any access.
                 break;
             default:
-                tiramisu::error("Replacing expression name for an unsupported tiramisu expression.", 1);
+                ERROR("Replacing expression name for an unsupported tiramisu expression.", 1);
         }
     }
 

--- a/src/tiramisu_core.cpp
+++ b/src/tiramisu_core.cpp
@@ -3493,12 +3493,16 @@ void computation::assert_names_not_assigned(
         int d = isl_map_find_dim_by_name(this->get_schedule(), isl_dim_out,
                                          dim.c_str());
         if (d >= 0)
-            tiramisu::error("Dimension " + dim + " is already in use.", true);
+        {
+            ERROR("Dimension " + dim + " is already in use.", true);
+        }
 
         d = isl_map_find_dim_by_name(this->get_schedule(), isl_dim_in,
                                      dim.c_str());
         if (d >= 0)
-            tiramisu::error("Dimension " + dim + " is already in use.", true);
+        {
+            ERROR("Dimension " + dim + " is already in use.", true);
+        }
     }
 }
 
@@ -3517,7 +3521,7 @@ void computation::check_dimensions_validity(std::vector<int> dimensions)
             isl_space_dim(isl_map_get_space(this->get_schedule()),
                           isl_dim_out))
         {
-            tiramisu::error("The dynamic dimension " +
+            ERROR("The dynamic dimension " +
                             std::to_string(loop_level_into_dynamic_dimension(dim)) +
                             " is not less than the number of dimensions of the "
                             "time-space domain " +
@@ -3655,7 +3659,9 @@ std::vector<int> computation::get_loop_level_numbers_from_dimension_names(
                                          isl_map_to_str(this->get_schedule())));
 
             if (d < 0)
-                tiramisu::error("Dimension " + dim + " not found.", true);
+            {
+                ERROR("Dimension " + dim + " not found.", true);
+            }
 
             DEBUG(10, tiramisu::str_dump("Corresponding loop level is " +
                                          std::to_string(dynamic_dimension_into_loop_level(d))));
@@ -3729,8 +3735,10 @@ std::vector<std::string> computation::get_iteration_domain_dimension_names()
             result.push_back(std::string(isl_set_get_dim_name(iter,
                                                               isl_dim_set, i)));
         else
-            tiramisu::error("All iteration domain dimensions must have "
+        {
+            ERROR("All iteration domain dimensions must have "
                             "a name.", true);
+        }
     }
 
     assert(result.size() == this->get_iteration_domain_dimensions_number());
@@ -5224,7 +5232,7 @@ int compute_recursively_max_AST_depth(isl_ast_node *node)
     }
     else
     {
-        tiramisu::error("Found an unsupported ISL AST node while computing the maximal AST depth.", true);
+        ERROR("Found an unsupported ISL AST node while computing the maximal AST depth.", true);
     }
 
     DEBUG(3, tiramisu::str_dump("Current depth = " + std::to_string(result)));
@@ -5259,7 +5267,9 @@ tiramisu::expr utility::extract_bound_expression(isl_ast_node *node, int dim, bo
     DEBUG(3, tiramisu::str_dump(std::string(isl_ast_node_to_C_str(node))));
 
     if (isl_ast_node_get_type(node) == isl_ast_node_block)
-        tiramisu::error("Currently Tiramisu does not support extracting bounds from blocks.", true);
+    {
+        ERROR("Currently Tiramisu does not support extracting bounds from blocks.", true);
+    }
     else if (isl_ast_node_get_type(node) == isl_ast_node_for)
     {
         DEBUG(3, tiramisu::str_dump("Extracting bounds from a for loop."));
@@ -5311,7 +5321,9 @@ tiramisu::expr utility::extract_bound_expression(isl_ast_node *node, int dim, bo
         assert(result.is_defined());
     }
     else if (isl_ast_node_get_type(node) == isl_ast_node_user)
-        tiramisu::error("Cannot extract bounds from a isl_ast_user node.", true);
+    {
+        ERROR("Cannot extract bounds from a isl_ast_user node.", true);
+    }
     else if (isl_ast_node_get_type(node) == isl_ast_node_if)
     {
         DEBUG(3, tiramisu::str_dump("If conditional."));
@@ -5324,7 +5336,7 @@ tiramisu::expr utility::extract_bound_expression(isl_ast_node *node, int dim, bo
         {
             // else_bound = utility::extract_bound_expression(isl_ast_node_if_get_else(node), dim, upper);
             // result = tiramisu::expr(tiramisu::o_s, cond_bound, then_bound, else_bound);
-            tiramisu::error("If Then Else is unsupported in bound extraction.", true);
+            ERROR("If Then Else is unsupported in bound extraction.", true);
         }
         else
             result = then_bound; //tiramisu::expr(tiramisu::o_cond, cond_bound, then_bound);
@@ -5803,7 +5815,7 @@ std::string tiramisu::function::get_gpu_thread_iterator(const std::string &comp,
             }
             else
             {
-                tiramisu::error("Level not mapped to GPU.", true);
+                ERROR("Level not mapped to GPU.", true);
             }
 
             std::string str = "Dimension " + std::to_string(lev0) +
@@ -5848,7 +5860,7 @@ std::string tiramisu::function::get_gpu_block_iterator(const std::string &comp, 
             }
             else
             {
-                tiramisu::error("Level not mapped to GPU.", true);
+                ERROR("Level not mapped to GPU.", true);
             }
 
             std::string str = "Dimension " + std::to_string(lev0) +
@@ -6208,7 +6220,7 @@ Halide::Argument::Kind halide_argtype_from_tiramisu_argtype(tiramisu::argument_t
 
     if (type == tiramisu::a_temporary)
     {
-        tiramisu::error("Buffer type \"temporary\" can't be translated to Halide.\n", true);
+        ERROR("Buffer type \"temporary\" can't be translated to Halide.\n", true);
     }
 
     if (type == tiramisu::a_input)
@@ -6529,7 +6541,7 @@ std::string str_tiramisu_type_op(tiramisu::op_t type)
     case tiramisu::o_trunc:
         return "trunc";
     default:
-        tiramisu::error("Tiramisu op not supported.", true);
+        ERROR("Tiramisu op not supported.", true);
         return "";
     }
 }
@@ -6557,7 +6569,7 @@ std::string str_from_tiramisu_type_expr(tiramisu::expr_t type)
     case tiramisu::e_sync:
         return "sync";
     default:
-        tiramisu::error("Tiramisu type not supported.", true);
+        ERROR("Tiramisu type not supported.", true);
         return "";
     }
 }
@@ -6573,7 +6585,7 @@ std::string str_from_tiramisu_type_argument(tiramisu::argument_t type)
     case tiramisu::a_temporary:
         return "temporary";
     default:
-        tiramisu::error("Tiramisu type not supported.", true);
+        ERROR("Tiramisu type not supported.", true);
         return "";
     }
 }
@@ -6607,7 +6619,7 @@ std::string str_from_tiramisu_type_primitive(tiramisu::primitive_t type)
     case tiramisu::p_wait_ptr:
         return "wait";
     default:
-        tiramisu::error("Tiramisu type not supported.", true);
+        ERROR("Tiramisu type not supported.", true);
         return "";
     }
 }
@@ -6755,7 +6767,7 @@ Halide::Type halide_type_from_tiramisu_type(tiramisu::primitive_t type)
         t = Halide::Handle();
         break;
     default:
-        tiramisu::error("Tiramisu type cannot be translated to Halide type.", true);
+        ERROR("Tiramisu type cannot be translated to Halide type.", true);
     }
     return t;
 }
@@ -6871,14 +6883,18 @@ void tiramisu::computation::init_computation(std::string iteration_space_str,
     if (same_name_computations.size() > 1)
     {
         if (isl_set_plain_is_universe(this->get_iteration_domain()))
-            tiramisu::error("Computations defined multiple times should"
+        {
+            ERROR("Computations defined multiple times should"
                             " have bounds on their iteration domain", true);
+        }
 
         for (auto c : same_name_computations)
         {
             if (isl_set_plain_is_universe(c->get_iteration_domain()))
-                tiramisu::error("Computations defined multiple times should"
+            {
+                ERROR("Computations defined multiple times should"
                                 " have bounds on their iteration domain", true);
+            }
         }
     }
 
@@ -7359,7 +7375,7 @@ void tiramisu::computation::set_access(std::string access_str)
     for (auto c : computations)
         if (isl_map_is_equal(this->get_access_relation(), c->get_access_relation()) == isl_bool_false)
         {
-            tiramisu::error("Computations that have the same name should also have the same access relation.",
+            ERROR("Computations that have the same name should also have the same access relation.",
                             true);
         }
 
@@ -7737,7 +7753,9 @@ std::string tiramisu::computation::construct_iteration_domain(std::vector<var> i
 	tiramisu::function *fct = global::get_implicit_function();
 
 	if (fct == NULL)
-	    tiramisu::error("An implicit function has to be created by providing a function name to init(NAME). Otherwise the low level API has to be called", true);
+    {
+	    ERROR("An implicit function has to be created by providing a function name to init(NAME). Otherwise the low level API has to be called", true);
+    }
 
 	const std::vector<std::string> inv = fct->get_invariant_names();
 
@@ -8179,7 +8197,7 @@ std::string create_send_func_name(const xfer_prop chan)
                 name += "_f64";
                 break;
             default: {
-                error("Channel not allowed", 27);
+                ERROR("Channel not allowed", 27);
                 break;
             }
         }
@@ -8327,7 +8345,7 @@ std::string create_recv_func_name(const xfer_prop chan)
                 name += "_f64";
                 break;
             default:
-                error("Channel type not allowed.", 27);
+                ERROR("Channel type not allowed.", 27);
         }
         return name;
     } else {
@@ -8580,7 +8598,7 @@ void tiramisu::function::lift_dist_comps() {
             if (chan.contains_attr(MPI)) {
                 lift_mpi_comp(*comp);
             } else {
-                tiramisu::error("Can only lift MPI library calls", 0);
+                ERROR("Can only lift MPI library calls", 0);
             }
         }
     }

--- a/src/tiramisu_debug.cpp
+++ b/src/tiramisu_debug.cpp
@@ -35,15 +35,4 @@ void print_indentation()
     }
 }
 
-void error(const std::string &str, bool exit_program)
-{
-    std::cerr << "Error in " << __FILE__ << ":"
-              << __LINE__ << " - " << str << std::endl;
-
-    if (exit_program)
-    {
-        exit(1);
-    }
-}
-
 }


### PR DESCRIPTION
Replacing the tiramisu::error function with ERROR macro so that now it correctly prints the file and line number of the error location.

Builds without errors.