### PR TITLE
Gitmodules ignore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,11 +2,14 @@
 	path = 3rdParty/Halide
 	url = https://github.com/jrayzero/Halide.git
 	branch = tiramisu_64_bit
+	ignore = all
 [submodule "3rdParty/llvm"]
 	path = 3rdParty/llvm
 	url = https://git.llvm.org/git/llvm.git/
 	branch = release_50
+	ignore = all
 [submodule "3rdParty/clang"]
 	path = 3rdParty/clang
 	url = https://git.llvm.org/git/clang.git/
 	branch = release_50
+	ignore = all


### PR DESCRIPTION
Git commands like `status` and `checkout` take too long to run especially on remote servers because llvm and clang submodules are huge. Adding `ignore = all` property to submodules so git doesn't check there modules when executing commands.

A fresh copy builds without errors (including install_submodules.sh) and all tests pass.