### PR TITLE
GPU Local buffer

### DIFF
--- a/include/tiramisu/core.h
+++ b/include/tiramisu/core.h
@@ -1285,6 +1285,8 @@ public:
     void tag_gpu_register();
     /* Tag the buffer as located in the GPU shared memory. */
     void tag_gpu_shared();
+    /* Tag the buffer as located in the GPU local thread memory. */
+    void tag_gpu_local();
     /* Tag the buffer as located in the GPU constant memory. */
     void tag_gpu_constant();
 

--- a/include/tiramisu/cuda_ast.h
+++ b/include/tiramisu/cuda_ast.h
@@ -179,6 +179,7 @@ enum class memory_location
     host,
     global,
     shared,
+    local,
     constant,
     reg,
 };

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -378,7 +378,9 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
                     case o_allocate:
                     {
                         auto buffer = get_buffer(tiramisu_expr.get_name());
-                        if (buffer->get_location() == memory_location::shared || buffer->get_location() == memory_location::reg)
+                        if (buffer->get_location() == memory_location::shared
+                                || buffer->get_location() == memory_location::local
+                                || buffer->get_location() == memory_location::reg)
                             return statement_ptr {new cuda_ast::declaration{buffer}};
                         else
                             return statement_ptr {new cuda_ast::allocate{buffer}};
@@ -576,7 +578,9 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
             {
                 this->gpu_local.insert(comp->get_expr().get_name());
                 auto buffer = get_buffer(comp->get_expr().get_name());
-                if (buffer->get_location() == memory_location::shared || buffer->get_location() == memory_location::reg)
+                if (buffer->get_location() == memory_location::shared
+                        || buffer->get_location() == memory_location::local
+                        || buffer->get_location() == memory_location::reg)
                     return statement_ptr {new cuda_ast::declaration{buffer}};
                 else
                     return statement_ptr {new cuda_ast::allocate{buffer}};
@@ -1297,9 +1301,13 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
     void cuda_ast::kernel::add_used_scalar(scalar_ptr scalar) {
         used_constants[scalar->get_name()] = scalar;
     }
+
     void cuda_ast::kernel::add_used_buffer(buffer_ptr buffer) {
-        if (buffer->get_location() != memory_location::shared && buffer->get_location() != memory_location::constant)
+        if (buffer->get_location() != memory_location::shared
+                && buffer->get_location() != memory_location::local
+                && buffer->get_location() != memory_location::constant) {
             used_buffers[buffer->get_name()] = buffer;
+        }
     }
 
     cuda_ast::host_function::host_function(primitive_t type, std::string name, const std::vector<abstract_identifier_ptr> &arguments, statement_ptr body) :

--- a/src/tiramisu_core.cpp
+++ b/src/tiramisu_core.cpp
@@ -8757,6 +8757,11 @@ void tiramisu::buffer::tag_gpu_global() {
     location = cuda_ast::memory_location::global;
 }
 
+void tiramisu::buffer::tag_gpu_local() {
+    location = cuda_ast::memory_location::local;
+    set_auto_allocate(false);
+}
+
 void tiramisu::buffer::tag_gpu_register() {
     bool is_single_val = this->get_n_dims() == 1 && this->get_dim_sizes()[0].get_expr_type() == e_val && this->get_dim_sizes()[0].get_int_val() == 1;
     assert(is_single_val && "Buffer needs to correspond to a single value to be in register");


### PR DESCRIPTION
Adding `buffer::tag_gpu_local` to be able to create GPU thread local array.

Builds without errors. I'll add benchmarks using local memory.