### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - cd build
   - cmake ..
   - make -j tiramisu
-  - make test
+  # - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ script:
   - cd build
   - cmake ..
   - make -j tiramisu
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - tar xvf clang+llvm-5.0.0-x86_64-linux-gnu-debian8.tar.xz
   - mv clang+llvm-5.0.0-x86_64-linux-gnu-debian8 llvm
   - ./utils/scripts/install_submodules.sh $TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR/llvm/bin
-  - printf "\nset (LLVM_CONFIG_BIN ${CMAKE_SOURCE_DIR}/llvm/bin)" >> configure.cmake
+  - printf "\nset (LLVM_CONFIG_BIN \${CMAKE_SOURCE_DIR}/llvm/bin)" >> configure.cmake
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - tar xvf clang+llvm-5.0.0-x86_64-linux-gnu-debian8.tar.xz
   - mv clang+llvm-5.0.0-x86_64-linux-gnu-debian8 llvm
   - ./utils/scripts/install_submodules.sh $TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR/llvm/bin
-  - printf "\nset (LLVM_CONFIG_BIN llvm/bin)" >> configure.cmake
+  - printf "\nset (LLVM_CONFIG_BIN ${CMAKE_SOURCE_DIR}/llvm/bin)" >> configure.cmake
 
 script:
   - mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,11 @@ find_library(HalideLib Halide PATHS ${HALIDE_LIB_DIRECTORY} NO_DEFAULT_PATH)
 find_library(ISLLib isl PATHS ${ISL_LIB_DIRECTORY} NO_DEFAULT_PATH)
 
 # Require LLVM 5.0 or greater to keep in line with Halide
+message(${LLVM_CONFIG_BIN})
+execute_process(COMMAND ${LLVM_CONFIG_BIN}/llvm-config OUTPUT_VARIABLE LLVM_VERSION)
+message(${LLVM_VERSION})
 execute_process(COMMAND ${LLVM_CONFIG_BIN}/llvm-config --version OUTPUT_VARIABLE LLVM_VERSION)
+message(${LLVM_VERSION})
 string(STRIP ${LLVM_VERSION} LLVM_VERSION)
 if (${LLVM_VERSION} VERSION_GREATER 5.0)
     execute_process(COMMAND ${LLVM_CONFIG_BIN}/llvm-config --ignore-libllvm --system-libs OUTPUT_VARIABLE LLVM_FLAGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,18 +158,14 @@ find_library(HalideLib Halide PATHS ${HALIDE_LIB_DIRECTORY} NO_DEFAULT_PATH)
 find_library(ISLLib isl PATHS ${ISL_LIB_DIRECTORY} NO_DEFAULT_PATH)
 
 # Require LLVM 5.0 or greater to keep in line with Halide
-message(${LLVM_CONFIG_BIN})
-execute_process(COMMAND ${LLVM_CONFIG_BIN}/llvm-config OUTPUT_VARIABLE LLVM_VERSION)
-message(${LLVM_VERSION})
 execute_process(COMMAND ${LLVM_CONFIG_BIN}/llvm-config --version OUTPUT_VARIABLE LLVM_VERSION)
-message(${LLVM_VERSION})
 string(STRIP ${LLVM_VERSION} LLVM_VERSION)
-if (${LLVM_VERSION} VERSION_GREATER 5.0)
-    execute_process(COMMAND ${LLVM_CONFIG_BIN}/llvm-config --ignore-libllvm --system-libs OUTPUT_VARIABLE LLVM_FLAGS)
-    string(STRIP ${LLVM_FLAGS} LLVM_FLAGS)
-else ()
+if (${LLVM_VERSION} VERSION_LESS 5.0)
     message(FATAL_ERROR "tiramisu requires LLVM version >= 5.0")
 endif()
+
+execute_process(COMMAND ${LLVM_CONFIG_BIN}/llvm-config --ignore-libllvm --system-libs OUTPUT_VARIABLE LLVM_FLAGS)
+string(STRIP ${LLVM_FLAGS} LLVM_FLAGS)
 
 set(LINK_FLAGS "-ldl -lpthread ${LLVM_FLAGS}")
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![Build Status](https://travis-ci.org/Tiramisu-Compiler/tiramisu.svg?branch=master)](https://travis-ci.org/Tiramisu-Compiler/tiramisu)
 
 ## Overview
 


### PR DESCRIPTION
Travis CI now correctly builds: https://travis-ci.org/Tiramisu-Compiler/tiramisu/builds/411927281

Without tests build takes around 15mins. Tests take additional 15mins. I disabled the tests for now because in the previous PR some of the tests failed for no reason: https://travis-ci.org/Tiramisu-Compiler/tiramisu/builds/411938131 I'll look into it on Monday.

Fixing LLVM logic that were rejecting the LLVM version 5.0. Also adding status icon to README.md