### PR TITLE
GPU GEMM Benchmark Updates

### DIFF
--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/CMakeLists.txt
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/CMakeLists.txt
@@ -3,7 +3,7 @@ set(generator_name ${benchmark_name}_generator)
 set(wrapper_name ${benchmark_name}_wrapper)
 set(object_files fct.o fct.o_cpu.o fct.o_gpu.o)
 
-add_executable(${generator_name} generator.cpp)
+add_executable(${generator_name} generator3.cpp)
 target_link_libraries(${generator_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLAGS} cuda_wrapper)
 add_custom_command(OUTPUT ${object_files} COMMAND ${generator_name} DEPENDS ${generator_name})
 

--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/README.md
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/README.md
@@ -1,7 +1,8 @@
 GPU Implementation of gemm. From the build directory:
 - `make run_benchmark_gpu_gemm` to run the benchmark
 - `make run_benchmark_gpu_gemm_nvprof` to see Nvidia profiles of Tiramisu and cublas kernels.
-- `make run_benchmark_gpu_gemm_correctness` to run the correctness test.
+- `make run_benchmark_gpu_gemm_correctness` to run the correctness test. Use smaller sizes to prevent precision errors.
 
-With current implementation kernel time scales with N^3 with respect to input dimensions (so does cublas).
-However CPU overhead grows faster thus the tiramisu-cublas margin increases as matrices get bigger.
+Note that the actual algorithm we are testing is transposed matrix multiplication where matrix B is transposed by default. Inputs and outputs are in row-major format.
+
+Since cublas is column-major by default, we swap inputs to get C in row major format. This assures that the operations are exactly same between Tiramisu and cublas. However, this is not the fastest cublas kernel. If C is made column-major, cublas gets ~10% faster.

--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/configuration.h
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/configuration.h
@@ -1,12 +1,16 @@
 #define DATA_TYPE float
 #define DATA_PTYPE p_float32
 
-#define BLOCK 8
+// GPU BLOCK
+#define BLOCK 16
+// REGISTER BLOCK
+#define R_BLOCK_I 8
+#define R_BLOCK_J 16
 
 // Dimensions need to be multiples of blocksize
-#define M 1024
-#define N 1024
-#define K 1024
+#define M 4096
+#define N 4096
+#define K 4096
 
 #define alpha ((float) 3)
 #define beta ((float) 2)

--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator2.cpp
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator2.cpp
@@ -1,0 +1,150 @@
+#include <tiramisu/tiramisu.h>
+
+#include "configuration.h"
+
+using namespace tiramisu;
+
+int main(int argc, char **argv)
+{
+    // Double tiling with Register and Shared memory
+
+    tiramisu::init("matmul");
+
+    // -------------------------------------------------------
+    // Layer I
+    // -------------------------------------------------------
+
+    // Declare loop iterators
+    var i("i", 0, M), j("j", 0, N), k("k", 0, K);
+    var i0("i0", 0, M / R_BLOCK_I), i1("i1", 0, R_BLOCK_I), j0("j0", 0, N / R_BLOCK_I), j1("j1", 0, R_BLOCK_I), k0("k0", 0, K / BLOCK), k1("k1", 0, BLOCK);
+    var i00("i00"), i01("i01"), j00("j00"), j01("j01");
+
+    // Declare cpu buffers.
+    buffer b_A("b_A", {M, K}, DATA_PTYPE, a_input);
+    buffer b_B("b_B", {K, N}, DATA_PTYPE, a_input);
+    buffer b_C("b_C", {M, N}, DATA_PTYPE, a_output);
+    // Declare gpu buffers.
+    buffer b_A_glb("b_A_glb", {M, K}, DATA_PTYPE, a_temporary);
+    buffer b_B_glb("b_B_glb", {K, N}, DATA_PTYPE, a_temporary);
+    buffer b_C_glb("b_C_glb", {M, N}, DATA_PTYPE, a_temporary);
+    buffer b_A_shr("b_A_shr", {BLOCK * R_BLOCK_I, BLOCK}, DATA_PTYPE, a_temporary);
+    buffer b_B_shr("b_B_shr", {BLOCK, BLOCK * R_BLOCK_I}, DATA_PTYPE, a_temporary);
+    buffer b_A_reg("b_A_reg", {R_BLOCK_I}, DATA_PTYPE, a_temporary);
+    buffer b_B_reg("b_B_reg", {R_BLOCK_I}, DATA_PTYPE, a_temporary);
+    buffer b_acc("b_acc", {R_BLOCK_I, R_BLOCK_I}, DATA_PTYPE, a_temporary);
+    b_A_glb.tag_gpu_global();
+    b_B_glb.tag_gpu_global();
+    b_C_glb.tag_gpu_global();
+    b_A_shr.tag_gpu_shared();
+    b_B_shr.tag_gpu_shared();
+    b_A_reg.tag_gpu_local();
+    b_B_reg.tag_gpu_local();
+    b_acc.tag_gpu_local();
+
+
+    // Declare input wrappers
+    input c_A_glb({i0, j0, k0, i1}, DATA_PTYPE);
+    input c_A_shr({i0, j0, k, i1}, DATA_PTYPE);
+    input c_A({i, k}, DATA_PTYPE);
+    input c_B_glb({i0, j0, k0, j1}, DATA_PTYPE);
+    input c_B_shr({i0, j0, k, j1}, DATA_PTYPE);
+    input c_B({k, j}, DATA_PTYPE);
+    // Declare computations
+    computation c_A_glb_to_shr({i0, j0, k0, i1}, c_A_glb(i0, j0, k0, i1));
+    computation c_A_shr_to_reg({i0, j0, k, i1}, c_A_shr(i0, j0, k, i1));
+    computation c_B_glb_to_shr({i0, j0, k0, j1}, c_B_glb(i0, j0, k0, j1));
+    computation c_B_shr_to_reg({i0, j0, k, j1}, c_B_shr(i0, j0, k, j1));
+    computation c_acc_init({i, j}, (float) 0);
+    computation c_acc({i, j, k}, DATA_PTYPE);
+    c_acc.set_expression(c_acc(i, j, 0) + c_A(i, k) * c_B(k, j));
+    computation c_C({i, j}, DATA_PTYPE);
+    c_C.set_expression(c_acc(i, j, 0) * alpha + c_C(i, j) * beta);
+    // Declare declarations
+    computation c_A_shr_dec({i0, j0}, allocate(b_A_shr));
+    computation c_A_reg_dec({i0, j0}, allocate(b_A_reg));
+    computation c_B_shr_dec({i0, j0}, allocate(b_B_shr));
+    computation c_B_reg_dec({i0, j0}, allocate(b_B_reg));
+    computation c_acc_dec({i0, j0}, allocate(b_acc));
+    // Declare synchronizer computations
+    computation c_sync1({i0, j0, k0}, tiramisu::sync());
+    computation c_sync2({i0, j0, k0}, tiramisu::sync());
+    // Declare host-gpu transfer computations.
+    computation copy_A_to_device({}, memcpy(b_A, b_A_glb));
+    computation copy_B_to_device({}, memcpy(b_B, b_B_glb));
+    computation copy_C_to_device({}, memcpy(b_C, b_C_glb));
+    computation copy_C_to_host({}, memcpy(b_C_glb, b_C));
+
+    // -------------------------------------------------------
+    // Layer II
+    // -------------------------------------------------------
+
+    // Scheduling commands
+
+    c_A_shr_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_A_reg_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_acc_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_A_glb_to_shr.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_A_shr_to_reg.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_A_shr_to_reg.split(k, BLOCK, k0, k1);
+    c_B_shr_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_B_reg_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_B_glb_to_shr.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_B_shr_to_reg.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_B_shr_to_reg.split(k, BLOCK, k0, k1);
+    c_acc_init.tile(i, j, R_BLOCK_I, R_BLOCK_I, i0, j0, i1, j1);
+    c_acc_init.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_acc.tile(i, j, R_BLOCK_I, R_BLOCK_I, i0, j0, i1, j1);
+    c_acc.interchange(j1, k);
+    c_acc.interchange(i1, k);
+    c_acc.split(k, BLOCK, k0, k1);
+    c_acc.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_C.tile(i, j, R_BLOCK_I, R_BLOCK_I, i0, j0, i1, j1);
+    c_C.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_sync1.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_sync2.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+
+    copy_A_to_device.then(copy_B_to_device, computation::root)
+                    .then(copy_C_to_device, computation::root)
+                    .then(c_A_shr_dec, computation::root)
+                    .then(c_B_shr_dec, j01)
+                    .then(c_A_reg_dec, j01)
+                    .then(c_B_reg_dec, j01)
+                    .then(c_acc_dec, j01)
+                    .then(c_acc_init, j01)
+                    .then(c_A_glb_to_shr, j01)
+                    .then(c_B_glb_to_shr, k0)
+                    .then(c_sync1, k0)
+                    .then(c_A_shr_to_reg, k0)
+                    .then(c_B_shr_to_reg, k1)
+                    .then(c_acc, k1)
+                    .then(c_sync2, k0)
+                    .then(c_C, j01)
+                    .then(copy_C_to_host, computation::root);
+
+    // -------------------------------------------------------
+    // Layer III
+    // -------------------------------------------------------
+
+    c_A_glb.store_in(&b_A_glb, {i0 * R_BLOCK_I + i1, k0 * BLOCK + j0 % BLOCK});
+    c_A_glb_to_shr.store_in(&b_A_shr, {i0 % BLOCK * R_BLOCK_I + i1, j0 % BLOCK});
+    c_A_shr.store_in(&b_A_shr, {i0 % BLOCK * R_BLOCK_I + i1, k % BLOCK});
+    c_A_shr_to_reg.store_in(&b_A_reg, {i1});
+    c_B_glb.store_in(&b_B_glb, {k0 * BLOCK + i0 % BLOCK, j0 * R_BLOCK_I + j1});
+    c_B_glb_to_shr.store_in(&b_B_shr, {i0 % BLOCK, j0 % BLOCK * R_BLOCK_I + j1});
+    c_B_shr.store_in(&b_B_shr, {k % BLOCK, j0 % BLOCK * R_BLOCK_I + j1});
+    c_B_shr_to_reg.store_in(&b_B_reg, {j1});
+    c_A.store_in(&b_A_reg, {i % R_BLOCK_I});
+    c_B.store_in(&b_B_reg, {j % R_BLOCK_I});
+    c_acc_init.store_in(&b_acc, {i % R_BLOCK_I, j % R_BLOCK_I});
+    c_acc.store_in(&b_acc, {i % R_BLOCK_I, j % R_BLOCK_I});
+    c_C.store_in(&b_C_glb);
+
+    // -------------------------------------------------------
+    // Code Generation
+    // -------------------------------------------------------
+
+    // Generate object files. Last argument triggers cuda compilation.
+    tiramisu::codegen({&b_A, &b_B, &b_C}, "fct.o", true);
+
+    return 0;
+}

--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator3.cpp
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator3.cpp
@@ -1,0 +1,153 @@
+#include <tiramisu/tiramisu.h>
+
+#include "configuration.h"
+
+using namespace tiramisu;
+
+int main(int argc, char **argv)
+{
+    // Double tiling with Register and Shared memory
+    // Fused A_reg and non-square tiling
+
+    tiramisu::init("matmul");
+
+    // -------------------------------------------------------
+    // Layer I
+    // -------------------------------------------------------
+
+    // Declare loop iterators
+    var i("i", 0, M), j("j", 0, N), k("k", 0, K);
+    var i0("i0", 0, M / R_BLOCK_I), i1("i1", 0, R_BLOCK_I), j0("j0", 0, N / R_BLOCK_J), j1("j1", 0, R_BLOCK_J), k0("k0", 0, K / BLOCK), k1("k1", 0, BLOCK);
+    var i00("i00"), i01("i01"), j00("j00"), j01("j01");
+
+    // Declare cpu buffers.
+    buffer b_A("b_A", {M, K}, DATA_PTYPE, a_input);
+    buffer b_B("b_B", {K, N}, DATA_PTYPE, a_input);
+    buffer b_C("b_C", {M, N}, DATA_PTYPE, a_output);
+    // Declare gpu buffers.
+    buffer b_A_glb("b_A_glb", {M, K}, DATA_PTYPE, a_temporary);
+    buffer b_B_glb("b_B_glb", {K, N}, DATA_PTYPE, a_temporary);
+    buffer b_C_glb("b_C_glb", {M, N}, DATA_PTYPE, a_temporary);
+    buffer b_A_shr("b_A_shr", {BLOCK, BLOCK * R_BLOCK_I}, DATA_PTYPE, a_temporary);
+    // "+ 1" to reduce shared memory bank conflicts
+    buffer b_B_shr("b_B_shr", {BLOCK, BLOCK * R_BLOCK_J + 1}, DATA_PTYPE, a_temporary);
+    buffer b_A_reg("b_A_reg", {1}, DATA_PTYPE, a_temporary);
+    buffer b_B_reg("b_B_reg", {R_BLOCK_J}, DATA_PTYPE, a_temporary);
+    buffer b_acc("b_acc", {R_BLOCK_I, R_BLOCK_J}, DATA_PTYPE, a_temporary);
+    b_A_glb.tag_gpu_global();
+    b_B_glb.tag_gpu_global();
+    b_C_glb.tag_gpu_global();
+    b_A_shr.tag_gpu_shared();
+    b_B_shr.tag_gpu_shared();
+    b_A_reg.tag_gpu_register();
+    b_B_reg.tag_gpu_local();
+    b_acc.tag_gpu_local();
+
+
+    // Declare input wrappers
+    input c_A_glb({i0, j0, k0, i1}, DATA_PTYPE);
+    input c_A_shr({i0, j0, k, i1}, DATA_PTYPE);
+    input c_A({i, k}, DATA_PTYPE);
+    input c_B_glb({i0, j0, k0, j1}, DATA_PTYPE);
+    input c_B_shr({i0, j0, k, j1}, DATA_PTYPE);
+    input c_B({k, j}, DATA_PTYPE);
+    // Declare computations
+    computation c_A_glb_to_shr({i0, j0, k0, i1}, c_A_glb(i0, j0, k0, i1));
+    computation c_A_shr_to_reg({i0, j0, k, i1}, c_A_shr(i0, j0, k, i1));
+    computation c_B_glb_to_shr({i0, j0, k0, j1}, c_B_glb(i0, j0, k0, j1));
+    computation c_B_shr_to_reg({i0, j0, k, j1}, c_B_shr(i0, j0, k, j1));
+    computation c_acc_init({i, j}, (float) 0);
+    computation c_acc({i, j, k}, DATA_PTYPE);
+    c_acc.set_expression(c_acc(i, j, 0) + c_A(i, k) * c_B(k, j));
+    computation c_C({i, j}, DATA_PTYPE);
+    c_C.set_expression(c_acc(i, j, 0) * alpha + c_C(i, j) * beta);
+    // Declare declarations
+    computation c_A_shr_dec({i0, j0}, allocate(b_A_shr));
+    computation c_A_reg_dec({i0, j0}, allocate(b_A_reg));
+    computation c_B_shr_dec({i0, j0}, allocate(b_B_shr));
+    computation c_B_reg_dec({i0, j0}, allocate(b_B_reg));
+    computation c_acc_dec({i0, j0}, allocate(b_acc));
+    // Declare synchronizer computations
+    computation c_sync1({i0, j0, k0}, tiramisu::sync());
+    computation c_sync2({i0, j0, k0}, tiramisu::sync());
+    // Declare host-gpu transfer computations.
+    computation copy_A_to_device({}, memcpy(b_A, b_A_glb));
+    computation copy_B_to_device({}, memcpy(b_B, b_B_glb));
+    computation copy_C_to_device({}, memcpy(b_C, b_C_glb));
+    computation copy_C_to_host({}, memcpy(b_C_glb, b_C));
+
+    // -------------------------------------------------------
+    // Layer II
+    // -------------------------------------------------------
+
+    // Scheduling commands
+
+    c_A_shr_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_A_reg_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_acc_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_A_glb_to_shr.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_A_shr_to_reg.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_A_shr_to_reg.split(k, BLOCK, k0, k1);
+    c_B_shr_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_B_reg_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_B_glb_to_shr.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_B_shr_to_reg.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_B_shr_to_reg.split(k, BLOCK, k0, k1);
+    c_acc_init.tile(i, j, R_BLOCK_I, R_BLOCK_J, i0, j0, i1, j1);
+    c_acc_init.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_acc.tile(i, j, R_BLOCK_I, R_BLOCK_J, i0, j0, i1, j1);
+    c_acc.interchange(j1, k);
+    c_acc.interchange(i1, k);
+    c_acc.split(k, BLOCK, k0, k1);
+    c_acc.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_C.tile(i, j, R_BLOCK_I, R_BLOCK_J, i0, j0, i1, j1);
+    c_C.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_sync1.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_sync2.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+
+    copy_A_to_device.then(copy_B_to_device, computation::root)
+                    .then(copy_C_to_device, computation::root)
+                    .then(c_A_shr_dec, computation::root)
+                    .then(c_B_shr_dec, j01)
+                    .then(c_A_reg_dec, j01)
+                    .then(c_B_reg_dec, j01)
+                    .then(c_acc_dec, j01)
+                    .then(c_acc_init, j01)
+                    .then(c_A_glb_to_shr, j01)
+                    .then(c_B_glb_to_shr, k0)
+                    .then(c_sync1, k0)
+                    .then(c_B_shr_to_reg, k0)
+                    .then(c_A_shr_to_reg, k1)
+                    .then(c_acc, i1)
+                    .then(c_sync2, k0)
+                    .then(c_C, j01)
+                    .then(copy_C_to_host, computation::root);
+
+    // -------------------------------------------------------
+    // Layer III
+    // -------------------------------------------------------
+
+    c_A_glb.store_in(&b_A_glb, {i0 * R_BLOCK_I + i1, k0 * BLOCK + j0 % BLOCK});
+    // Note the transpose:
+    c_A_glb_to_shr.store_in(&b_A_shr, {j0 % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
+    c_A_shr.store_in(&b_A_shr, {k % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
+    c_A_shr_to_reg.store_in(&b_A_reg, {0});
+    c_B_glb.store_in(&b_B_glb, {k0 * BLOCK + i0 % BLOCK, j0 * R_BLOCK_J + j1});
+    c_B_glb_to_shr.store_in(&b_B_shr, {i0 % BLOCK, j0 % BLOCK * R_BLOCK_J + j1});
+    c_B_shr.store_in(&b_B_shr, {k % BLOCK, j0 % BLOCK * R_BLOCK_J + j1});
+    c_B_shr_to_reg.store_in(&b_B_reg, {j1});
+    c_A.store_in(&b_A_reg, {i % R_BLOCK_I});
+    c_B.store_in(&b_B_reg, {j % R_BLOCK_J});
+    c_acc_init.store_in(&b_acc, {i % R_BLOCK_I, j % R_BLOCK_J});
+    c_acc.store_in(&b_acc, {i % R_BLOCK_I, j % R_BLOCK_J});
+    c_C.store_in(&b_C_glb);
+
+    // -------------------------------------------------------
+    // Code Generation
+    // -------------------------------------------------------
+
+    // Generate object files. Last argument triggers cuda compilation.
+    tiramisu::codegen({&b_A, &b_B, &b_C}, "fct.o", true);
+
+    return 0;
+}

--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator3.cpp
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator3.cpp
@@ -22,11 +22,11 @@ int main(int argc, char **argv)
 
     // Declare cpu buffers.
     buffer b_A("b_A", {M, K}, DATA_PTYPE, a_input);
-    buffer b_B("b_B", {K, N}, DATA_PTYPE, a_input);
+    buffer b_B("b_B", {N, K}, DATA_PTYPE, a_input);
     buffer b_C("b_C", {M, N}, DATA_PTYPE, a_output);
     // Declare gpu buffers.
     buffer b_A_glb("b_A_glb", {M, K}, DATA_PTYPE, a_temporary);
-    buffer b_B_glb("b_B_glb", {K, N}, DATA_PTYPE, a_temporary);
+    buffer b_B_glb("b_B_glb", {N, K}, DATA_PTYPE, a_temporary);
     buffer b_C_glb("b_C_glb", {M, N}, DATA_PTYPE, a_temporary);
     buffer b_A_shr("b_A_shr", {BLOCK, BLOCK * R_BLOCK_I}, DATA_PTYPE, a_temporary);
     // "+ 1" to reduce shared memory bank conflicts
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
     c_A_glb_to_shr.store_in(&b_A_shr, {j0 % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
     c_A_shr.store_in(&b_A_shr, {k % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
     c_A_shr_to_reg.store_in(&b_A_reg, {0});
-    c_B_glb.store_in(&b_B_glb, {k0 * BLOCK + i0 % BLOCK, j0 * R_BLOCK_J + j1});
+    c_B_glb.store_in(&b_B_glb, {j0 * R_BLOCK_J + j1, k0 * BLOCK + i0 % BLOCK,});
     c_B_glb_to_shr.store_in(&b_B_shr, {i0 % BLOCK, j0 % BLOCK * R_BLOCK_J + j1});
     c_B_shr.store_in(&b_B_shr, {k % BLOCK, j0 % BLOCK * R_BLOCK_J + j1});
     c_B_shr_to_reg.store_in(&b_B_reg, {j1});


### PR DESCRIPTION
Updating GPU GEMM Benchmark to use both shared and register tiling. Also changing spec to use transposed matrix multiplication where matrix B is assumed to be transposed already.

With input matrices of size 4096x4096:

|                               | cublas  | Tiramisu |
|-------------------------------|---------|----------|
| Single Run GPU Kernel Time    | 73.5ms  | 183ms    |
| 100 Runs Average CPU+GPU Time | 105.8ms | 172.7ms  |

Kernel time measurement has profiler overhead and doing more runs reduces the average time, but I'm not sure about the reason why cublas CPU overhead is bigger.

There's room for improvement for tuning parameters, prefetching, and optimizing memory access patterns.