### PR TITLE
ppcg gpu gemm benchmark

### DIFF
--- a/benchmarks/framework_benchmarking/linear_algebra/ppcg-gpu_sgemm/makefile
+++ b/benchmarks/framework_benchmarking/linear_algebra/ppcg-gpu_sgemm/makefile
@@ -1,0 +1,17 @@
+CUDA_ROOT = /usr/local/cuda
+PPCG = ../../software/ppcg/ppcg
+
+run_sgemm: sgemm
+	./sgemm
+
+sgemm: sgemm_host.cu sgemm_kernel.o
+	${CUDA_ROOT}/bin/nvcc sgemm_host.cu sgemm_kernel.o -o sgemm
+
+sgemm_kernel.o: sgemm_kernel.hu sgemm_kernel.cu
+	${CUDA_ROOT}/bin/nvcc sgemm_kernel.cu -c sgemm_kernel.o
+
+sgemm_host.cu sgemm_kernel.hu sgemm_kernel.cu: sgemm.c
+	${PPCG} --target=cuda sgemm.c
+
+clean:
+	-rm sgemm_host.cu sgemm_kernel.hu sgemm_kernel.cu sgemm_kernel.o sgemm

--- a/benchmarks/framework_benchmarking/linear_algebra/ppcg-gpu_sgemm/sgemm.c
+++ b/benchmarks/framework_benchmarking/linear_algebra/ppcg-gpu_sgemm/sgemm.c
@@ -41,7 +41,7 @@ int main() {
     float alpha = 3;
     float beta = 2;
     // Warm up
-    for (int i = 0; i< 10; i++) {
+    for (int i = 0; i < 10; i++) {
         sgemm(A, B, C, alpha, beta);
     }
     int testN = 100;

--- a/benchmarks/framework_benchmarking/linear_algebra/ppcg-gpu_sgemm/sgemm.c
+++ b/benchmarks/framework_benchmarking/linear_algebra/ppcg-gpu_sgemm/sgemm.c
@@ -1,0 +1,56 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+
+#define M 3072
+#define N 3072
+#define K 3072
+
+float* new_matrix(int rows, int cols) {
+    float* m = (float*)malloc(rows * cols * sizeof(float));
+    // Random values
+    for (int i = 0; i < rows; i++) {
+        for (int j = 0; j < cols; j++) {
+            m[i * cols + j] = rand() % 100;
+        }
+    }
+    return m;
+}
+
+int clock_t_comparator(const void* a, const void* b) {
+    return (*(clock_t*)a > *(clock_t*)b) - (*(clock_t*)a < *(clock_t*)b);
+}
+
+void sgemm(float *A, float *B, float *C, float alpha, float beta) {
+#pragma scop
+    for (int i = 0; i < M; i++) {
+        for (int j = 0; j < N; j++) {
+            C[i * N + j] = beta * C[i * N + j];
+            for (int k = 0; k < K; k++) {
+                C[i * N + j] += alpha * A[i * K + k] * B[k * N + j];
+            }
+        }
+    }
+#pragma endscop
+}
+
+int main() {
+    float *A = new_matrix(M, K);
+    float *B = new_matrix(K, N);
+    float *C = new_matrix(M, N);
+    float alpha = 3;
+    float beta = 2;
+    // Warm up
+    for (int i = 0; i< 10; i++) {
+        sgemm(A, B, C, alpha, beta);
+    }
+    int testN = 100;
+    clock_t times[testN];
+    for (int i = 0; i < testN; i++) {
+        clock_t t = clock();
+        sgemm(A, B, C, alpha, beta);
+        times[i] = clock() - t;
+    }
+    qsort(times, testN, sizeof(clock_t), clock_t_comparator);
+    printf("median time: %.2fms\n", ((float)times[testN / 2]) / CLOCKS_PER_SEC * 1000);
+}


### PR DESCRIPTION
Adding PPCG benchmark for SGEMM. Compiled PPCG code doesn't use shared memory and only does 2x1 register tiling. Multiplying 3072x3072 matrices:

|          | Total Time  |
|----------|-------|
| cuBLAS   | 46ms  |g
| Tiramisu | 77ms  |
| PPCG     | 445ms |