### PR TITLE
Build llvm with nvptx by default

### DIFF
--- a/utils/scripts/install_submodules.sh
+++ b/utils/scripts/install_submodules.sh
@@ -65,7 +65,7 @@ if [ "$2" = "" ]; then
         echo_and_run_cmd "mkdir prefix/"
     fi
     echo_and_run_cmd "cd build"
-    echo_and_run_cmd "$CMAKE -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64;Mips;PowerPC' -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Release .. -DCMAKE_INSTALL_PREFIX=$PWD/../prefix/ -DLLVM_EXTERNAL_CLANG_SOURCE_DIR=${PROJECT_SRC_DIR}/3rdParty/clang"
+    echo_and_run_cmd "$CMAKE -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_TARGETS_TO_BUILD='X86;ARM;AArch64;Mips;NVPTX;PowerPC' -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Release .. -DCMAKE_INSTALL_PREFIX=$PWD/../prefix/ -DLLVM_EXTERNAL_CLANG_SOURCE_DIR=${PROJECT_SRC_DIR}/3rdParty/clang"
     echo_and_run_cmd "make -j $CORES"
     echo_and_run_cmd "make install"
 else


### PR DESCRIPTION
Built with NVPTX on computers with and without CUDA support. Benchmarks run for both.