### PR TITLE
Enable Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - cd build
   - cmake ..
   - make -j tiramisu
-  # - make test
+  - make test

--- a/src/tiramisu_codegen_halide.cpp
+++ b/src/tiramisu_codegen_halide.cpp
@@ -3763,6 +3763,8 @@ void function::gen_halide_obj(const std::string &obj_file_name, Halide::Target::
 {
     // TODO(tiramisu): For GPU schedule, we need to set the features, e.g.
     // Halide::Target::OpenCL, etc.
+    // Note: "make test" fails on Travis machines when AVX2 is used.
+    //       Disable travis tests in .travis.yml if you switch to AVX2.
     std::vector<Halide::Target::Feature> features =
             {
                     Halide::Target::AVX, Halide::Target::SSE41,// Halide::Target::OpenCL,


### PR DESCRIPTION
Now that we switched to AVX from AVX2 with commit https://github.com/Tiramisu-Compiler/tiramisu/commit/7274375cd5e85500119a8c2e68fc7d6619e88a95, we can enable Travis to run the `make test` to assure that tests pass. This increases build time by about 10-12 mins.