### PR TITLE
GPU GEMM Tiling update

### DIFF
--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/configuration.h
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/configuration.h
@@ -4,7 +4,7 @@
 // GPU BLOCK
 #define BLOCK 16
 // REGISTER BLOCK
-#define R_BLOCK_I 12
+#define R_BLOCK_I 6
 #define R_BLOCK_J 16
 // R_BLOCK_J needs to be equal to BLOCK because of
 // the way we copy B from global to shared


### PR DESCRIPTION
Reducing the register tile size from 12x16 to 6x16 gives marginal improvement: 77ms -> 73ms. This might be an indicator that some memory copy is slow. I'll look into that.

Interestingly, tile size 8x16 is slower than both (83ms) even though it's in the middle.