### PR TITLE
GPU Gemm Improvements

### DIFF
--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/CMakeLists.txt
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/CMakeLists.txt
@@ -13,6 +13,6 @@ set_target_properties(${wrapper_name} PROPERTIES COMPILE_FLAGS -O3)
 target_link_libraries(${wrapper_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLAGS} cuda_wrapper ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
 
 add_custom_target(run_${benchmark_name} COMMAND ${wrapper_name} 100 0 DEPENDS ${wrapper_name})
-add_custom_target(run_${benchmark_name}_nvprof COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --print-gpu-trace $<TARGET_FILE:${wrapper_name}> 1 0 DEPENDS ${wrapper_name})
-add_custom_target(run_${benchmark_name}_nvprof2 COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof $<TARGET_FILE:${wrapper_name}> 100 0 DEPENDS ${wrapper_name})
+add_custom_target(run_${benchmark_name}_nvprof COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --profile-from-start off --print-gpu-trace $<TARGET_FILE:${wrapper_name}> 1 0 DEPENDS ${wrapper_name})
+add_custom_target(run_${benchmark_name}_nvprof2 COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --profile-from-start off $<TARGET_FILE:${wrapper_name}> 100 0 DEPENDS ${wrapper_name})
 add_custom_target(run_${benchmark_name}_correctness COMMAND ${wrapper_name} 0 1 DEPENDS ${wrapper_name})

--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator3.cpp
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator3.cpp
@@ -18,6 +18,7 @@ int main(int argc, char **argv)
     // Declare loop iterators
     var i("i", 0, M), j("j", 0, N), k("k", 0, K);
     var i0("i0", 0, M / R_BLOCK_I), i1("i1", 0, R_BLOCK_I), j0("j0", 0, N / R_BLOCK_J), j1("j1", 0, R_BLOCK_J), k0("k0", 0, K / BLOCK), k1("k1", 0, BLOCK);
+    var k0_skiplast("k0", 0, K / BLOCK - 1);
     var i00("i00"), i01("i01"), j00("j00"), j01("j01");
 
     // Declare cpu buffers.
@@ -30,8 +31,8 @@ int main(int argc, char **argv)
     buffer b_B_glb("b_B_glb", {K, N}, DATA_PTYPE, a_temporary);
     buffer b_C_glb("b_C_glb", {M, N}, DATA_PTYPE, a_temporary);
     // "+ 1" to reduce shared memory bank conflicts
-    buffer b_A_shr("b_A_shr", {BLOCK, BLOCK * R_BLOCK_I + 1}, DATA_PTYPE, a_temporary);
-    buffer b_B_shr("b_B_shr", {BLOCK, BLOCK * R_BLOCK_J}, DATA_PTYPE, a_temporary);
+    buffer b_A_shr("b_A_shr", {2, BLOCK, BLOCK * R_BLOCK_I + 1}, DATA_PTYPE, a_temporary);
+    buffer b_B_shr("b_B_shr", {2, BLOCK, BLOCK * R_BLOCK_J}, DATA_PTYPE, a_temporary);
     buffer b_A_reg("b_A_reg", {1}, DATA_PTYPE, a_temporary);
     buffer b_B_reg("b_B_reg", {R_BLOCK_J}, DATA_PTYPE, a_temporary);
     buffer b_acc("b_acc", {R_BLOCK_I, R_BLOCK_J}, DATA_PTYPE, a_temporary);
@@ -47,19 +48,21 @@ int main(int argc, char **argv)
 
     // Declare input wrappers
     input c_A_glb({i0, j0, k0, i1}, DATA_PTYPE);
-    input c_A_shr({i0, j0, k, i1}, DATA_PTYPE);
+    input c_A_shr({i0, j0, k0, k1, i1}, DATA_PTYPE);
     input c_A({i, k}, DATA_PTYPE);
     input c_B_glb({i0, j0, k0, j1}, DATA_PTYPE);
-    input c_B_shr({i0, j0, k, j1}, DATA_PTYPE);
+    input c_B_shr({i0, j0, k0, k1, j1}, DATA_PTYPE);
     input c_B({k, j}, DATA_PTYPE);
     input c_Consts({i}, DATA_PTYPE);
     constant c_alpha("alpha", c_Consts(0));
     constant c_beta("beta", c_Consts(1));
     // Declare computations
-    computation c_A_glb_to_shr({i0, j0, k0, i1}, c_A_glb(i0, j0, k0, i1));
-    computation c_A_shr_to_reg({i0, j0, k, i1}, c_A_shr(i0, j0, k, i1));
-    computation c_B_glb_to_shr({i0, j0, k0, j1}, c_B_glb(i0, j0, k0, j1));
-    computation c_B_shr_to_reg({i0, j0, k, j1}, c_B_shr(i0, j0, k, j1));
+    computation c_A_glb_to_shr_pre({i0, j0, i1}, c_A_glb(i0, j0, 0, i1));
+    computation c_A_glb_to_shr({i0, j0, k0_skiplast, i1}, c_A_glb(i0, j0, k0_skiplast + 1, i1));
+    computation c_A_shr_to_reg({i0, j0, k0, k1, i1}, c_A_shr(i0, j0, k0, k1, i1));
+    computation c_B_glb_to_shr_pre({i0, j0, j1}, c_B_glb(i0, j0, 0, j1));
+    computation c_B_glb_to_shr({i0, j0, k0_skiplast, j1}, c_B_glb(i0, j0, k0_skiplast + 1, j1));
+    computation c_B_shr_to_reg({i0, j0, k0, k1, j1}, c_B_shr(i0, j0, k0, k1, j1));
     computation c_acc_init({i, j}, (float) 0);
     computation c_acc({i, j, k}, DATA_PTYPE);
     c_acc.set_expression(c_acc(i, j, 0) + c_A(i, k) * c_B(k, j));
@@ -72,7 +75,7 @@ int main(int argc, char **argv)
     computation c_B_reg_dec({i0, j0}, allocate(b_B_reg));
     computation c_acc_dec({i0, j0}, allocate(b_acc));
     // Declare synchronizer computations
-    computation c_sync1({i0, j0, k0}, tiramisu::sync());
+    computation c_sync1({i0, j0}, tiramisu::sync());
     computation c_sync2({i0, j0, k0}, tiramisu::sync());
     // Declare host-gpu transfer computations.
     computation copy_A_to_device({}, memcpy(b_A, b_A_glb));
@@ -89,14 +92,14 @@ int main(int argc, char **argv)
     c_A_shr_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
     c_A_reg_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
     c_acc_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_A_glb_to_shr_pre.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
     c_A_glb_to_shr.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
     c_A_shr_to_reg.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
-    c_A_shr_to_reg.split(k, BLOCK, k0, k1);
     c_B_shr_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
     c_B_reg_dec.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
+    c_B_glb_to_shr_pre.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
     c_B_glb_to_shr.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
     c_B_shr_to_reg.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
-    c_B_shr_to_reg.split(k, BLOCK, k0, k1);
     c_acc_init.tile(i, j, R_BLOCK_I, R_BLOCK_J, i0, j0, i1, j1);
     c_acc_init.gpu_tile(i0, j0, BLOCK, BLOCK, i00, j00, i01, j01);
     c_acc.tile(i, j, R_BLOCK_I, R_BLOCK_J, i0, j0, i1, j1);
@@ -117,9 +120,11 @@ int main(int argc, char **argv)
                     .then(c_B_reg_dec, j01)
                     .then(c_acc_dec, j01)
                     .then(c_acc_init, j01)
+                    .then(c_A_glb_to_shr_pre, j01)
+                    .then(c_B_glb_to_shr_pre, j01)
+                    .then(c_sync1, j01)
                     .then(c_A_glb_to_shr, j01)
                     .then(c_B_glb_to_shr, k0)
-                    .then(c_sync1, k0)
                     .then(c_B_shr_to_reg, k0)
                     .then(c_A_shr_to_reg, k1)
                     .then(c_acc, i1)
@@ -133,14 +138,16 @@ int main(int argc, char **argv)
 
     c_A_glb.store_in(&b_A_glb, {i0 * R_BLOCK_I + i1, k0 * BLOCK + j0 % BLOCK});
     // Note the transpose:
-    c_A_glb_to_shr.store_in(&b_A_shr, {j0 % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
-    c_A_shr.store_in(&b_A_shr, {k % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
+    c_A_glb_to_shr_pre.store_in(&b_A_shr, {0, j0 % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
+    c_A_glb_to_shr.store_in(&b_A_shr, {(k0_skiplast + 1) % 2, j0 % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
+    c_A_shr.store_in(&b_A_shr, {k0 % 2, k1, i0 % BLOCK * R_BLOCK_I + i1});
     c_A_shr_to_reg.store_in(&b_A_reg, {0});
     // Note that we use a transposed mapping to assure memory coalescing
     // This requires R_BLOCK_J to be equal to BLOCK
     c_B_glb.store_in(&b_B_glb, {k0 * BLOCK + j1, j0 * R_BLOCK_J + i0 % BLOCK});
-    c_B_glb_to_shr.store_in(&b_B_shr, {j1, j0 % BLOCK * R_BLOCK_J + i0 % BLOCK});
-    c_B_shr.store_in(&b_B_shr, {k % BLOCK, j0 % BLOCK * R_BLOCK_J + j1});
+    c_B_glb_to_shr_pre.store_in(&b_B_shr, {0, j1, j0 % BLOCK * R_BLOCK_J + i0 % BLOCK});
+    c_B_glb_to_shr.store_in(&b_B_shr, {(k0_skiplast + 1) % 2, j1, j0 % BLOCK * R_BLOCK_J + i0 % BLOCK});
+    c_B_shr.store_in(&b_B_shr, {k0 % 2, k1, j0 % BLOCK * R_BLOCK_J + j1});
     c_B_shr_to_reg.store_in(&b_B_reg, {j1});
     c_A.store_in(&b_A_reg, {i % R_BLOCK_I});
     c_B.store_in(&b_B_reg, {j % R_BLOCK_J});

--- a/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator3.cpp
+++ b/benchmarks/linear_algebra/blas/level3/sgemm/gpu/generator3.cpp
@@ -136,10 +136,10 @@ int main(int argc, char **argv)
     // Layer III
     // -------------------------------------------------------
 
-    c_A_glb.store_in(&b_A_glb, {i0 * R_BLOCK_I + i1, k0 * BLOCK + j0 % BLOCK});
+    c_A_glb.store_in(&b_A_glb, {(i0 - i0 % BLOCK + j0 % BLOCK) * R_BLOCK_I + i1, k0 * BLOCK + i0 % BLOCK});
     // Note the transpose:
-    c_A_glb_to_shr_pre.store_in(&b_A_shr, {0, j0 % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
-    c_A_glb_to_shr.store_in(&b_A_shr, {(k0_skiplast + 1) % 2, j0 % BLOCK, i0 % BLOCK * R_BLOCK_I + i1});
+    c_A_glb_to_shr_pre.store_in(&b_A_shr, {0, i0 % BLOCK, j0 % BLOCK * R_BLOCK_I + i1});
+    c_A_glb_to_shr.store_in(&b_A_shr, {(k0_skiplast + 1) % 2, i0 % BLOCK, j0 % BLOCK * R_BLOCK_I + i1});
     c_A_shr.store_in(&b_A_shr, {k0 % 2, k1, i0 % BLOCK * R_BLOCK_I + i1});
     c_A_shr_to_reg.store_in(&b_A_reg, {0});
     // Note that we use a transposed mapping to assure memory coalescing


### PR DESCRIPTION
Adding prefetching and global memory coalescing on warp level to GPU Gemm.

I realized the kernel run time doesn't reach steady state for 10-15 runs. So I've increased the warm up runs. I've also fixed a global memory coalescing issue I found in profiler. Here are the latest numbers (GPU time, 3072x3072):

|                 | Pascal 4 | Kepler 80 (Salike) |
|-----------------|----------|--------------------|
| Old             | 20ms     | 73ms               |
| After Prefetch  | 19.2ms   | 74.5ms             |
| **After Coalescing** | **18.3ms**   | **62.5ms**             |
| cuBLAS          | 10.8ms   | 28ms               |

Note that unlike P4, prefetching decreases the performance slightly on K80. But combined, we get improvements of 9% on P4 and 15% on K80 with this diff.

**Next steps:** Now profiler shows some issues with shared memory. Also disassembling cuBLAS shows that they are using bulk memory operations and more unrolling.