### PR TITLE
Fix GPU Kernel bugs

### DIFF
--- a/include/tiramisu/core.h
+++ b/include/tiramisu/core.h
@@ -280,7 +280,7 @@ private:
      */
     std::vector<std::string> iterator_names;
 
-    std::unordered_map<std::string, std::list<cuda_ast::kernel_ptr>> iterator_to_kernel_list;
+    std::unordered_map<isl_ast_node*, std::list<cuda_ast::kernel_ptr>> iterator_to_kernel_list;
 
     std::shared_ptr<cuda_ast::compiler> nvcc_compiler;
 
@@ -4342,7 +4342,7 @@ protected:
                                                             int level,
                                                             std::vector<std::pair<std::string, std::string>> &tagged_stmts,
                                                             bool is_a_child_block,
-                                                            std::unordered_map<std::string, std::list<cuda_ast::kernel_ptr>> &iterator_to_kernel_map);
+                                                            std::unordered_map<isl_ast_node*, std::list<cuda_ast::kernel_ptr>> &iterator_to_kernel_map);
 
     // TODO doc
     static Halide::Internal::Stmt make_halide_block(const Halide::Internal::Stmt &first,

--- a/include/tiramisu/cuda_ast.h
+++ b/include/tiramisu/cuda_ast.h
@@ -47,12 +47,6 @@ namespace tiramisu
     };
     typedef std::unique_ptr<isl_id, isl_id_deleter> isl_id_ptr;
 
-    struct isl_ast_node_deleter
-    {
-        void operator()(isl_ast_node * p) const {isl_ast_node_free(p);}
-    };
-    typedef std::unique_ptr<isl_ast_node, isl_ast_node_deleter> isl_ast_node_ptr;
-
     struct isl_ast_node_list_deleter
     {
         void operator()(isl_ast_node_list * p) const {isl_ast_node_list_free(p);}
@@ -670,7 +664,7 @@ private:
     cuda_ast::statement_ptr parse_tiramisu(const tiramisu::expr & tiramisu_expr);
     int loop_level = 0;
     kernel_ptr current_kernel;
-    std::unordered_map<std::string, std::list<kernel_ptr>> iterator_to_kernel_map;
+    std::unordered_map<isl_ast_node*, std::list<kernel_ptr>> iterator_to_kernel_map;
     std::vector<kernel_ptr> kernels;
     // Will be set to true as soon as GPU computation is encountered, and set to false as soon as GPU loop is exited
     bool in_kernel = false;
@@ -690,14 +684,14 @@ private:
 public:
     explicit generator(tiramisu::function &fct);
 
-    statement_ptr cuda_stmt_from_isl_node(isl_ast_node_ptr &node);
-    statement_ptr cuda_stmt_handle_isl_for(isl_ast_node_ptr &node);
-    statement_ptr cuda_stmt_val_from_for_condition(isl_ast_expr_ptr &expr, isl_ast_node_ptr &node);
-    statement_ptr cuda_stmt_handle_isl_block(isl_ast_node_ptr &node);
-    statement_ptr cuda_stmt_handle_isl_if(isl_ast_node_ptr &node);
-    statement_ptr cuda_stmt_handle_isl_user(isl_ast_node_ptr &node);
-    cuda_ast::statement_ptr cuda_stmt_handle_isl_expr(isl_ast_expr_ptr &expr, isl_ast_node_ptr &node);
-    statement_ptr cuda_stmt_handle_isl_op_expr(isl_ast_expr_ptr &expr, isl_ast_node_ptr &node);
+    statement_ptr cuda_stmt_from_isl_node(isl_ast_node *node);
+    statement_ptr cuda_stmt_handle_isl_for(isl_ast_node *node);
+    statement_ptr cuda_stmt_val_from_for_condition(isl_ast_expr_ptr &expr, isl_ast_node *node);
+    statement_ptr cuda_stmt_handle_isl_block(isl_ast_node *node);
+    statement_ptr cuda_stmt_handle_isl_if(isl_ast_node *node);
+    statement_ptr cuda_stmt_handle_isl_user(isl_ast_node *node);
+    cuda_ast::statement_ptr cuda_stmt_handle_isl_expr(isl_ast_expr_ptr &expr, isl_ast_node *node);
+    statement_ptr cuda_stmt_handle_isl_op_expr(isl_ast_expr_ptr &expr, isl_ast_node *node);
     void cuda_stmt_foreach_isl_expr_list(isl_ast_expr *node, const std::function<void(int, isl_ast_expr *)> &fn, int start = 0);
 
 

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -279,6 +279,14 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
                 gpu_local.clear();
                 kernel_simplified_vars.clear();
                 current_kernel->set_body(statement_ptr{final_body});
+                // Add previous iterators as arguments to the kernel:
+                for (auto it = iterator_stack.begin(); it != iterator_stack.end() - 1; it++) {
+                    current_kernel->add_used_scalar(
+                        scalar_ptr{new cuda_ast::scalar{
+                            tiramisu::global::get_loop_iterator_data_type(),
+                            *it,
+                            cuda_ast::memory_location::reg}});
+                }
                 kernels.push_back(current_kernel);
                 result = statement_ptr{new kernel_call{current_kernel}};
                 iterator_to_kernel_map[node].push_back(current_kernel);

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -152,8 +152,8 @@ const std::string tiramisu_type_to_cuda_type(tiramisu::primitive_t t) {
 
 namespace tiramisu {
 
-cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_node_ptr &node) {
-        isl_ast_node_type type = isl_ast_node_get_type(node.get());
+cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_node *node) {
+        isl_ast_node_type type = isl_ast_node_get_type(node);
 
         switch (type) {
             case isl_ast_node_for:
@@ -171,14 +171,14 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         }
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_if(isl_ast_node_ptr &node) {
-        isl_ast_node_ptr then_body{isl_ast_node_if_get_then(node.get())};
-        isl_ast_expr_ptr condition{isl_ast_node_if_get_cond(node.get())};
+    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_if(isl_ast_node *node) {
+        isl_ast_node *then_body = isl_ast_node_if_get_then(node);
+        isl_ast_expr_ptr condition{isl_ast_node_if_get_cond(node)};
 
         statement_ptr then_body_stmt{cuda_stmt_from_isl_node(then_body)};
         statement_ptr else_body_stmt;
-        if (isl_ast_node_if_has_else(node.get())) {
-            isl_ast_node_ptr else_body{isl_ast_node_if_get_else(node.get())};
+        if (isl_ast_node_if_has_else(node)) {
+            isl_ast_node *else_body = isl_ast_node_if_get_else(node);
             else_body_stmt = cuda_stmt_from_isl_node(else_body);
         }
 
@@ -192,12 +192,12 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
 
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_block(isl_ast_node_ptr &node) {
-        isl_ast_node_list_ptr children_list{isl_ast_node_block_get_children(node.get())};
+    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_block(isl_ast_node *node) {
+        isl_ast_node_list_ptr children_list{isl_ast_node_block_get_children(node)};
         const int block_length = isl_ast_node_list_n_ast_node(children_list.get());
         auto *b = new block;
         for (int i = 0; i < block_length; i++) {
-            isl_ast_node_ptr child_node{isl_ast_node_list_get_ast_node(children_list.get(), i)};
+            isl_ast_node *child_node = isl_ast_node_list_get_ast_node(children_list.get(), i);
             b->add_statement(cuda_stmt_from_isl_node(child_node));
         }
         return statement_ptr{b};
@@ -213,7 +213,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         }
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_val_from_for_condition(isl_ast_expr_ptr &expr, isl_ast_node_ptr &node)
+    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_val_from_for_condition(isl_ast_expr_ptr &expr, isl_ast_node *node)
     {
         // TODO this is potentially a hack
         assert(isl_ast_expr_get_type(expr.get()) == isl_ast_expr_type::isl_ast_expr_op);
@@ -231,17 +231,17 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
 
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_for(isl_ast_node_ptr &node) {
-        isl_ast_expr_ptr iterator{isl_ast_node_for_get_iterator(node.get())};
+    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_for(isl_ast_node *node) {
+        isl_ast_expr_ptr iterator{isl_ast_node_for_get_iterator(node)};
         isl_id_ptr iterator_id{isl_ast_expr_get_id(iterator.get())};
         std::string iterator_name(isl_id_get_name(iterator_id.get()));
         DEBUG(3, tiramisu::str_dump("The iterator name is: ", iterator_name.c_str()));
 
 
-        isl_ast_expr_ptr condition{isl_ast_node_for_get_cond(node.get())};
-        isl_ast_expr_ptr incrementor{isl_ast_node_for_get_inc(node.get())};
-        isl_ast_expr_ptr initializer{isl_ast_node_for_get_init(node.get())};
-        isl_ast_node_ptr body{isl_ast_node_for_get_body(node.get())};
+        isl_ast_expr_ptr condition{isl_ast_node_for_get_cond(node)};
+        isl_ast_expr_ptr incrementor{isl_ast_node_for_get_inc(node)};
+        isl_ast_expr_ptr initializer{isl_ast_node_for_get_init(node)};
+        isl_ast_node *body = isl_ast_node_for_get_body(node);
 
 
         // TODO check if degenerate
@@ -281,7 +281,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
                 current_kernel->set_body(statement_ptr{final_body});
                 kernels.push_back(current_kernel);
                 result = statement_ptr{new kernel_call{current_kernel}};
-                iterator_to_kernel_map[iterator_name].push_back(current_kernel);
+                iterator_to_kernel_map[node].push_back(current_kernel);
                 current_kernel.reset();
                 in_kernel = false;
             } else {
@@ -317,7 +317,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
     }
 
     cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_expr(isl_ast_expr_ptr &expr,
-                                                                                     isl_ast_node_ptr &node) {
+                                                                                     isl_ast_node *node) {
         isl_ast_expr_type type = isl_ast_expr_get_type(expr.get());
         switch (type) {
             case isl_ast_expr_op: DEBUG(3, tiramisu::str_dump("isl op"));
@@ -499,10 +499,10 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
     }
 
     cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_op_expr(isl_ast_expr_ptr &expr,
-                                                                                        isl_ast_node_ptr &node) {
+                                                                                        isl_ast_node *node) {
         isl_ast_op_type op_type = isl_ast_expr_get_op_type(expr.get());
         if (op_type == isl_ast_op_call) {
-            auto *comp = get_computation_annotated_in_a_node(node.get());
+            auto *comp = get_computation_annotated_in_a_node(node);
             // TODO use lower bound
             if (!this->in_kernel) {
                 for (auto &comp_gpu_pair : this->m_fct.gpu_block_dimensions) {
@@ -682,8 +682,8 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
 
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_user(isl_ast_node_ptr &node) {
-        isl_ast_expr_ptr expr{isl_ast_node_user_get_expr(node.get())};
+    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_user(isl_ast_node *node) {
+        isl_ast_expr_ptr expr{isl_ast_node_user_get_expr(node)};
         return cuda_stmt_handle_isl_expr(expr, node);
     }
 
@@ -696,8 +696,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         cuda_ast::generator generator{*this};
 
         auto *body = new cuda_ast::block;
-        isl_ast_node_ptr isl_main_body{isl_ast_node_copy(this->get_isl_ast())};
-        auto main_body = generator.cuda_stmt_from_isl_node(isl_main_body);
+        auto main_body = generator.cuda_stmt_from_isl_node(this->get_isl_ast());
 
         for (auto &kernel : generator.kernels)
         {

--- a/src/tiramisu_codegen_halide.cpp
+++ b/src/tiramisu_codegen_halide.cpp
@@ -1612,7 +1612,7 @@ Halide::Internal::Stmt
 tiramisu::generator::halide_stmt_from_isl_node(const tiramisu::function &fct, isl_ast_node *node, int level,
                                                std::vector<std::pair<std::string, std::string>> &tagged_stmts,
                                                bool is_a_child_block,
-                                               std::unordered_map<std::string, std::list<cuda_ast::kernel_ptr>> &iterator_to_kernel_map)
+                                               std::unordered_map<isl_ast_node*, std::list<cuda_ast::kernel_ptr>> &iterator_to_kernel_map)
 {
     assert(node != NULL);
     assert(level >= 0);
@@ -1881,7 +1881,7 @@ tiramisu::generator::halide_stmt_from_isl_node(const tiramisu::function &fct, is
         char *cstr = isl_ast_expr_to_C_str(iter);
         std::string iterator_str = std::string(cstr);
 
-        auto it_kernel = iterator_to_kernel_map.find(iterator_str);
+        auto it_kernel = iterator_to_kernel_map.find(node);
 
         if (it_kernel != iterator_to_kernel_map.end())
         {


### PR DESCRIPTION
Removing isl_ast_node_ptr and using direct isl_ast_node*'s to map kernels to loops. Also adding wrapping loop iterators to kernels as arguments.

I will add a test for this fix as well.