### PR TITLE
LSTM GPU Update

### DIFF
--- a/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
@@ -5,6 +5,7 @@ using namespace tiramisu;
 int main(int argc, char **argv)
 {
     // Single LSTM block without minibatching
+    // Biases, R weights, and W weights are merged to reduce the number of GEMMs
     tiramisu::init("lstm");
 
     // -------------------------------------------------------
@@ -19,34 +20,26 @@ int main(int argc, char **argv)
 
     // Inner dimensions
     var i("i", 0, feature_size), j("j", 0, feature_size), k("k", 0, batch_size);
+    var i_merged("i_m", 0, feature_size * 4);
     // Outer dimensions
     var l("l", 0, num_layers), m("m", 0, seq_length);
     var i0("i0"), i1("i1"), k0("k0"), k1("k1");
 
-    input R_i("R_i", {l, i, j}, p_float32);
-    input R_z("R_z", {l, i, j}, p_float32);
-    input R_o("R_o", {l, i, j}, p_float32);
-    input R_f("R_f", {l, i, j}, p_float32);
-    input W_i("W_i", {l, i, j}, p_float32);
-    input W_z("W_z", {l, i, j}, p_float32);
-    input W_o("W_o", {l, i, j}, p_float32);
-    input W_f("W_f", {l, i, j}, p_float32);
-    input b_i("b_i", {l, i}, p_float32);
-    input b_z("b_z", {l, i}, p_float32);
-    input b_o("b_o", {l, i}, p_float32);
-    input b_f("b_f", {l, i}, p_float32);
-    input x({m, k, i}, p_float32);
+    input R("R", {l, i_merged, j}, p_float32);
+    input W("W", {l, i_merged, j}, p_float32);
+    input b("b", {l, i_merged}, p_float32);
+    input x("x", {m, k, i}, p_float32);
 
     buffer buf_params("buf_params", {4}, p_int32, a_input);
-    buffer buf_Weights("buf_Weights", {num_layers, 8, feature_size, feature_size}, p_float32, a_input);
-    buffer buf_biases("buf_biases", {num_layers, 4, feature_size}, p_float32, a_input);
+    buffer buf_Weights("buf_Weights", {num_layers, 2, 4 * feature_size, feature_size}, p_float32, a_input);
+    buffer buf_biases("buf_biases", {num_layers, 4 * feature_size}, p_float32, a_input);
     buffer buf_x("buf_x", {seq_length, batch_size, feature_size}, p_float32, a_input);
     buffer buf_y("buf_y", {seq_length, batch_size, feature_size}, p_float32, a_output);
-    buffer buf_Weights_gpu("buf_Weights_gpu", {num_layers, 8, feature_size, feature_size}, p_float32, a_temporary);
-    buffer buf_biases_gpu("buf_biases_gpu", {num_layers, 4, feature_size}, p_float32, a_temporary);
+    buffer buf_Weights_gpu("buf_Weights_gpu", {num_layers, 2, 4 * feature_size, feature_size}, p_float32, a_temporary);
+    buffer buf_biases_gpu("buf_biases_gpu", {num_layers, 4 * feature_size}, p_float32, a_temporary);
     buffer buf_x_gpu("buf_x_gpu", {seq_length, batch_size, feature_size}, p_float32, a_temporary);
     buffer buf_y_gpu("buf_y_gpu", {seq_length, batch_size, feature_size}, p_float32, a_temporary);
-    buffer buf_workspace("buf_workspace", {num_layers, 4, batch_size, feature_size}, p_float32, a_temporary);
+    buffer buf_workspace("buf_workspace", {num_layers, batch_size, 4 * feature_size}, p_float32, a_temporary);
     buffer buf_h("buf_h", {seq_length + 1, num_layers + 1, batch_size, feature_size}, p_float32, a_temporary);
     buffer buf_c("buf_c", {seq_length + 1, num_layers, batch_size, feature_size}, p_float32, a_temporary);
 
@@ -67,23 +60,18 @@ int main(int argc, char **argv)
     computation h_init({l, k, i}, expr(float(0)));
     computation c_init({l, k, i}, expr(float(0)));
     computation h_copy_x({m, k, i}, x(m, k, i));
-    computation sum_i_init({m, l, k, i}, b_i(l, i));
-    computation sum_z_init({m, l, k, i}, b_z(l, i));
-    computation sum_o_init({m, l, k, i}, b_o(l, i));
-    computation sum_f_init({m, l, k, i}, b_f(l, i));
-    computation sum_i({m, l, k, i, j}, sum_i_init(m, l, k, i) + R_i(l, i, j) * h(m - 1, l, k, j) + W_i(l, i, j) * h(m, l - 1, k, j));
-    computation sum_z({m, l, k, i, j}, sum_z_init(m, l, k, i) + R_z(l, i, j) * h(m - 1, l, k, j) + W_z(l, i, j) * h(m, l - 1, k, j));
-    computation sum_o({m, l, k, i, j}, sum_o_init(m, l, k, i) + R_o(l, i, j) * h(m - 1, l, k, j) + W_o(l, i, j) * h(m, l - 1, k, j));
-    computation sum_f({m, l, k, i, j}, sum_f_init(m, l, k, i) + R_f(l, i, j) * h(m - 1, l, k, j) + W_f(l, i, j) * h(m, l - 1, k, j));
+    computation matmul_base({m, l, k, i_merged}, b(l, i_merged));
+    computation matmul1({m, l, k, i_merged, j}, matmul_base(m, l, k, i_merged) + R(l, i_merged, j) * h(m - 1, l, k, j));
+    computation matmul2({m, l, k, i_merged, j}, matmul_base(m, l, k, i_merged) + W(l, i_merged, j) * h(m, l - 1, k, j));
     #define sigmoid(x) expr(float(1)) / (1 + expr(o_expo, -(x)))
-    computation sig_i({m, l, k, i}, sigmoid(sum_i(m, l, k, i, 0)));
-    computation tnh_z({m, l, k, i}, expr(o_tanh, sum_z(m, l, k, i, 0)));
-    computation sig_o({m, l, k, i}, sigmoid(sum_o(m, l, k, i, 0)));
-    computation sig_f({m, l, k, i}, sigmoid(sum_f(m, l, k, i, 0)));
-    computation mul_iz({m, l, k, i}, sig_i(m, l, k, i) * tnh_z(m, l, k, i));
-    computation mul_fc({m, l, k, i}, sig_f(m, l, k, i) * c(m - 1, l, k, i));
+    computation sig_i("sig_i", {m, l, k, i}, sigmoid(matmul_base(m, l, k, i)));
+    computation tnh_z("tnh_z", {m, l, k, i}, expr(o_tanh, matmul_base(m, l, k, i + feature_size)));
+    computation sig_o("sig_o", {m, l, k, i}, sigmoid(matmul_base(m, l, k, i + 2 * feature_size)));
+    computation sig_f("sig_f", {m, l, k, i}, sigmoid(matmul_base(m, l, k, i + 3 * feature_size)));
+    computation mul_iz("mul_iz", {m, l, k, i}, sig_i(m, l, k, i) * tnh_z(m, l, k, i));
+    computation mul_fc("mul_fc", {m, l, k, i}, sig_f(m, l, k, i) * c(m - 1, l, k, i));
     c.set_expression(mul_iz(m, l, k, i) + mul_fc(m, l, k, i));
-    computation tnh_c({m, l, k, i}, expr(o_tanh, c(m, l, k, i)));
+    computation tnh_c("tnh_c", {m, l, k, i}, expr(o_tanh, c(m, l, k, i)));
     h.set_expression(tnh_c(m, l, k, i) * sig_o(m, l, k, i));
     // Output is the last layer
     computation y({m, k, i}, h(m, num_layers - 1, k, i));
@@ -111,14 +99,9 @@ int main(int argc, char **argv)
     h_init.gpu_tile(k, i, block, block, k0, i0, k1, i1);
     c_init.gpu_tile(k, i, block, block, k0, i0, k1, i1);
     h_copy_x.gpu_tile(k, i, block, block, k0, i0, k1, i1);
-    sum_i_init.gpu_tile(k, i, block, block, k0, i0, k1, i1);
-    sum_z_init.gpu_tile(k, i, block, block, k0, i0, k1, i1);
-    sum_o_init.gpu_tile(k, i, block, block, k0, i0, k1, i1);
-    sum_f_init.gpu_tile(k, i, block, block, k0, i0, k1, i1);
-    sum_i.gpu_tile(k, i, block, block, k0, i0, k1, i1);
-    sum_z.gpu_tile(k, i, block, block, k0, i0, k1, i1);
-    sum_o.gpu_tile(k, i, block, block, k0, i0, k1, i1);
-    sum_f.gpu_tile(k, i, block, block, k0, i0, k1, i1);
+    matmul_base.gpu_tile(k, i_merged, block, block, k0, i0, k1, i1);
+    matmul1.gpu_tile(k, i_merged, block, block, k0, i0, k1, i1);
+    matmul2.gpu_tile(k, i_merged, block, block, k0, i0, k1, i1);
     sig_i.gpu_tile(k, i, block, block, k0, i0, k1, i1);
     tnh_z.gpu_tile(k, i, block, block, k0, i0, k1, i1);
     sig_o.gpu_tile(k, i, block, block, k0, i0, k1, i1);
@@ -136,15 +119,10 @@ int main(int argc, char **argv)
         .then(h_init, i1)
         .then(c_init, i1)
         .then(h_copy_x, i1)
-        .then(sum_i_init, computation::root)
-        .then(sum_i, i1)
-        .then(sum_z_init, computation::root)
-        .then(sum_z, i1)
-        .then(sum_o_init, computation::root)
-        .then(sum_o, i1)
-        .then(sum_f_init, computation::root)
-        .then(sum_f, i1)
-        .then(sig_i, computation::root)
+        .then(matmul_base, computation::root)
+        .then(matmul1, l)
+        .then(matmul2, l)
+        .then(sig_i, l)
         .then(tnh_z, i1)
         .then(sig_o, i1)
         .then(sig_f, i1)
@@ -162,35 +140,22 @@ int main(int argc, char **argv)
 
     params.store_in(&buf_params);
     // Weights and biases are packed
-    R_i.store_in(&buf_Weights_gpu, {l, 0, i, j});
-    R_z.store_in(&buf_Weights_gpu, {l, 1, i, j});
-    R_o.store_in(&buf_Weights_gpu, {l, 2, i, j});
-    R_f.store_in(&buf_Weights_gpu, {l, 3, i, j});
-    W_i.store_in(&buf_Weights_gpu, {l, 4, i, j});
-    W_z.store_in(&buf_Weights_gpu, {l, 5, i, j});
-    W_o.store_in(&buf_Weights_gpu, {l, 6, i, j});
-    W_f.store_in(&buf_Weights_gpu, {l, 7, i, j});
-    b_i.store_in(&buf_biases_gpu, {l, 0, i});
-    b_z.store_in(&buf_biases_gpu, {l, 1, i});
-    b_o.store_in(&buf_biases_gpu, {l, 2, i});
-    b_f.store_in(&buf_biases_gpu, {l, 3, i});
+    R.store_in(&buf_Weights_gpu, {l, 0, i_merged, j});
+    W.store_in(&buf_Weights_gpu, {l, 1, i_merged, j});
+    b.store_in(&buf_biases_gpu, {l, i_merged});
     x.store_in(&buf_x_gpu);
     y.store_in(&buf_y_gpu);
-    sum_i_init.store_in(&buf_workspace, {l, 0, k, i});
-    sum_z_init.store_in(&buf_workspace, {l, 1, k, i});
-    sum_o_init.store_in(&buf_workspace, {l, 2, k, i});
-    sum_f_init.store_in(&buf_workspace, {l, 3, k, i});
-    sum_i.store_in(&buf_workspace, {l, 0, k, i});
-    sum_z.store_in(&buf_workspace, {l, 1, k, i});
-    sum_o.store_in(&buf_workspace, {l, 2, k, i});
-    sum_f.store_in(&buf_workspace, {l, 3, k, i});
-    sig_i.store_in(&buf_workspace, {l, 0, k, i});
-    tnh_z.store_in(&buf_workspace, {l, 1, k, i});
-    sig_o.store_in(&buf_workspace, {l, 2, k, i});
-    sig_f.store_in(&buf_workspace, {l, 3, k, i});
-    mul_iz.store_in(&buf_workspace, {l, 0, k, i});
-    mul_fc.store_in(&buf_workspace, {l, 3, k, i});
-    tnh_c.store_in(&buf_workspace, {l, 0, k, i});
+    matmul_base.store_in(&buf_workspace, {l, k, i_merged});
+    matmul1.store_in(&buf_workspace, {l, k, i_merged});
+    matmul2.store_in(&buf_workspace, {l, k, i_merged});
+    // Workaround for missing store_in feature
+    sig_i.set_access("[feature_size] -> {sig_i[m, l, k, i] -> buf_workspace[l, k, i + 0 * feature_size]}");
+    tnh_z.set_access("[feature_size] -> {tnh_z[m, l, k, i] -> buf_workspace[l, k, i + 1 * feature_size]}");
+    sig_o.set_access("[feature_size] -> {sig_o[m, l, k, i] -> buf_workspace[l, k, i + 2 * feature_size]}");
+    sig_f.set_access("[feature_size] -> {sig_f[m, l, k, i] -> buf_workspace[l, k, i + 3 * feature_size]}");
+    mul_iz.set_access("[feature_size] -> {mul_iz[m, l, k, i] -> buf_workspace[l, k, i + 0 * feature_size]}");
+    mul_fc.set_access("[feature_size] -> {mul_fc[m, l, k, i] -> buf_workspace[l, k, i + 3 * feature_size]}");
+    tnh_c.set_access("[feature_size] -> {tnh_c[m, l, k, i] -> buf_workspace[l, k, i + 0 * feature_size]}");
     h.store_in(&buf_h, {m + 1, l + 1, k, i});
     c.store_in(&buf_c, {m + 1, l, k, i});
     h_init.store_in(&buf_h, {0, l, k, i});

--- a/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
@@ -21,8 +21,8 @@ int main(int argc, char *argv[])
 
     // Note that indices are flipped (see tutorial 2)
     Halide::Buffer<int32_t> buf_params(4);
-    Halide::Buffer<float> buf_Weights(feature_size, feature_size, 8, num_layers);
-    Halide::Buffer<float> buf_biases(feature_size, 4, num_layers);
+    Halide::Buffer<float> buf_Weights(feature_size, 4 * feature_size, 2, num_layers);
+    Halide::Buffer<float> buf_biases(4 * feature_size, num_layers);
     Halide::Buffer<float> buf_x(feature_size, batch_size, seq_length);
     Halide::Buffer<float> buf_y(feature_size, batch_size, seq_length);
 


### PR DESCRIPTION
Adding shared memory to GEMM's in LSTM. This improves the performance by about 7x. I haven't analyzed coalescing and implemented register blocking yet so there's room for improvement.

The program runs in ~140ms on K80. The Nvidia blog post's baseline is 310ms and their end result is 28ms on an M40.