### PR TITLE
LSTM tile size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,8 +155,8 @@ find_library(ISLLib isl PATHS ${ISL_LIB_DIRECTORY} NO_DEFAULT_PATH)
 
 # Require LLVM 5.0 or greater to keep in line with Halide
 execute_process(COMMAND ${LLVM_CONFIG_BIN}/llvm-config --version OUTPUT_VARIABLE LLVM_VERSION)
-string(STRIP ${LLVM_VERSION} LLVM_VERSION)
-if (${LLVM_VERSION} VERSION_LESS 5.0)
+string(STRIP "${LLVM_VERSION}" LLVM_VERSION)
+if ("${LLVM_VERSION}" VERSION_LESS 5.0)
     message(FATAL_ERROR "tiramisu requires LLVM version >= 5.0")
 endif()
 

--- a/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
@@ -2,7 +2,7 @@
 
 using namespace tiramisu;
 
-#define BLOCK 16
+#define BLOCK 8
 
 int main(int argc, char **argv)
 {
@@ -23,10 +23,10 @@ int main(int argc, char **argv)
     // Inner dimensions
     var i("i", 0, feature_size), j("j", 0, feature_size), k("k", 0, batch_size);
     var i_merged("i_m", 0, feature_size * 4);
+    var i0("i0"), i1("i1"), k0("k0"), k1("k1");
     var j0("j0", 0, feature_size / BLOCK), j1("j1", 0, BLOCK);
     // Outer dimensions
     var l("l", 0, num_layers), m("m", 0, seq_length);
-    var i0("i0"), i1("i1"), k0("k0"), k1("k1");
 
     input R("R", {l, i_merged, j}, p_float32);
     input W("W", {l, i_merged, j}, p_float32);

--- a/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
@@ -10,8 +10,8 @@ typedef std::chrono::duration<double,std::milli> duration_t;
 
 int main(int argc, char *argv[])
 {
-    int testN = 1;
-    int warmupN = 5;
+    int testN = 100;
+    int warmupN = 20;
 
     // Gemm requires these sizes to be constant
     int feature_size = 512;


### PR DESCRIPTION
Changing LSTM GEMM tile size to 8, which gives huge improvement! Also fixing a CMake bug.

I tried skewing with inner loop parallelization as well but it doesn't seem to give any improvement. It probably requires CUDA streams for parallelization (which we don't have). 

The previous benchmarks were on Salike. I switched to Pascal4 (Google cloud) for benchmarks and it's actually pretty close to Nvidia blogpost with this last change:

| Program   | Time  |
|-----------------|-------|
| Old (16 tile)   | 87ms  |
| New (8 tile)    | ~38ms |
| Nvidia Blogpost | ~35ms |

Also Nvidia's code runs slower than they reported (27.8ms). Their run was on Maxwell40, which is an older architecture but maybe it's better than Pascal4.

Finally, I tried to implement a cuDNN benchmark directly from library, but it is extremely tedious and complicated so I stopped halfway through. It's still a better idea to compare it to a library that uses cuDNN as backend.

TODO: We still need to check for correctness.