### PR TITLE
LSTM cudnn comparison

### DIFF
--- a/benchmarks/DNN/blocks/LSTM/gpu/CMakeLists.txt
+++ b/benchmarks/DNN/blocks/LSTM/gpu/CMakeLists.txt
@@ -2,6 +2,7 @@ set(benchmark_name benchmark_lstm_gpu)
 set(generator_name ${benchmark_name}_generator)
 set(wrapper_name ${benchmark_name}_wrapper)
 set(object_files lstm.o lstm.o_gpu.o lstm.o_cpu.o)
+set(cudnn_location /data/scratch/akkas/cudnn7) # Change with the cudnn library location
 #set(gemm_generator_name ${benchmark_name}_gemm_generator)
 #set(gemm_object_files gemm.o gemm.o_gpu.o gemm.o_cpu.o)
 
@@ -13,8 +14,10 @@ add_custom_command(OUTPUT ${object_files} COMMAND ${generator_name} DEPENDS ${ge
 #target_link_libraries(${gemm_generator_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLAGS} cuda_wrapper ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
 #add_custom_command(OUTPUT ${gemm_object_files} COMMAND ${gemm_generator_name} DEPENDS ${gemm_generator_name})
 
+find_library(cudnn cudnn PATHS ${cudnn_location}/lib64 NO_DEFAULT_PATH)
 add_executable(${wrapper_name} wrapper.cpp ${object_files})
-target_link_libraries(${wrapper_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLAGS} cuda_wrapper ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
+target_link_libraries(${wrapper_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLAGS} cuda_wrapper ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES} ${cudnn})
+target_include_directories(${wrapper_name} PUBLIC ${cudnn_location}/include)
 
 add_custom_target(run_${benchmark_name} COMMAND ${wrapper_name})
 add_custom_target(run_${benchmark_name}_nvprof2 COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --profile-from-start off $<TARGET_FILE:${wrapper_name}> DEPENDS ${wrapper_name})

--- a/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
@@ -5,6 +5,7 @@
 #include <cuda_profiler_api.h>
 
 #include "wrapper.h"
+#include "wrapper_cudnn.h"
 
 typedef std::chrono::duration<double,std::milli> duration_t;
 
@@ -55,11 +56,26 @@ int main(int argc, char *argv[])
         durations.push_back(t2 - t1);
     }
 
-    if (testN > 0) {
-        std::cout << "LSTM median runtime: " << median(durations) << "ms" << std::endl << std::flush;
+    std::cout << "LSTM done" << std::endl;
+
+    setup_cudnn(seq_length, num_layers, batch_size, feature_size);
+
+    std::vector<duration_t> cudnn_durations;
+    for (int i = 0; i < testN; i++) {
+        auto t1 = std::chrono::high_resolution_clock::now();
+        run_cudnn();
+        auto t2 = std::chrono::high_resolution_clock::now();
+        cudnn_durations.push_back(t2 - t1);
     }
 
-    std::cout << "LSTM done" << std::endl;
+    free_cudnn();
+
+    std::cout << "cudnn done" << std::endl;
+
+    if (testN > 0) {
+        std::cout << "LSTM median runtime: " << median(durations) << "ms" << std::endl << std::flush;
+        std::cout << "cudnn median runtime: " << median(cudnn_durations) << "ms" << std::endl << std::flush;
+    }
 
     return 0;
 }

--- a/benchmarks/DNN/blocks/LSTM/gpu/wrapper_cudnn.h
+++ b/benchmarks/DNN/blocks/LSTM/gpu/wrapper_cudnn.h
@@ -1,0 +1,315 @@
+#include <cudnn.h>
+#include <cuda.h>
+#include <stdio.h>
+
+#define cudaErrCheck(stat) { cudaErrCheck_((stat), __FILE__, __LINE__); }
+void cudaErrCheck_(cudaError_t stat, const char *file, int line) {
+   if (stat != cudaSuccess) {
+      fprintf(stderr, "CUDA Error: %s %s %d\n", cudaGetErrorString(stat), file, line);
+   }
+}
+
+#define cudnnErrCheck(stat) { cudnnErrCheck_((stat), __FILE__, __LINE__); }
+void cudnnErrCheck_(cudnnStatus_t stat, const char *file, int line) {
+   if (stat != CUDNN_STATUS_SUCCESS) {
+      fprintf(stderr, "cuDNN Error: %s %s %d\n", cudnnGetErrorString(stat), file, line);
+   }
+}
+
+// Global variables
+int seqLength;
+
+void *x;
+void *hx = NULL;
+void *cx = NULL;
+
+void *y;
+void *hy = NULL;
+void *cy = NULL;
+
+void *w;
+
+cudnnHandle_t cudnnHandle;
+cudnnRNNDescriptor_t rnnDesc;
+cudnnTensorDescriptor_t *xDesc, *yDesc;
+cudnnTensorDescriptor_t hxDesc, cxDesc;
+cudnnTensorDescriptor_t hyDesc, cyDesc;
+cudnnFilterDescriptor_t wDesc;
+
+void *workspace;
+size_t workSize;
+
+void setup_cudnn(int _seqLength, int numLayers, int batch_size, int feature_size) {
+    seqLength = _seqLength;
+    int hiddenSize = feature_size;
+    int inputSize = hiddenSize;
+    int miniBatch = batch_size;
+
+    // -------------------------
+    // Create cudnn context
+    // -------------------------
+    cudnnErrCheck(cudnnCreate(&cudnnHandle));
+
+    // -------------------------
+    // Set up inputs and outputs
+    // -------------------------
+    cudaErrCheck(cudaMalloc((void**)&x, seqLength * inputSize * miniBatch * sizeof(float)));
+    cudaErrCheck(cudaMalloc((void**)&hx, numLayers * hiddenSize * miniBatch * sizeof(float)));
+    cudaErrCheck(cudaMalloc((void**)&cx, numLayers * hiddenSize * miniBatch * sizeof(float)));
+
+    cudaErrCheck(cudaMalloc((void**)&y, seqLength * hiddenSize * miniBatch * sizeof(float)));
+    cudaErrCheck(cudaMalloc((void**)&hy, numLayers * hiddenSize * miniBatch * sizeof(float)));
+    cudaErrCheck(cudaMalloc((void**)&cy, numLayers * hiddenSize * miniBatch * sizeof(float)));
+
+    xDesc = (cudnnTensorDescriptor_t*)malloc(seqLength * sizeof(cudnnTensorDescriptor_t));
+    yDesc = (cudnnTensorDescriptor_t*)malloc(seqLength * sizeof(cudnnTensorDescriptor_t));
+
+    int dimA[3];
+    int strideA[3];
+
+    for (int i = 0; i < seqLength; i++) {
+        cudnnErrCheck(cudnnCreateTensorDescriptor(&xDesc[i]));
+        cudnnErrCheck(cudnnCreateTensorDescriptor(&yDesc[i]));
+
+        dimA[0] = miniBatch;
+        dimA[1] = inputSize;
+        dimA[2] = 1;
+
+        strideA[0] = dimA[2] * dimA[1];
+        strideA[1] = dimA[2];
+        strideA[2] = 1;
+
+        cudnnErrCheck(cudnnSetTensorNdDescriptor(xDesc[i], CUDNN_DATA_FLOAT, 3, dimA, strideA));
+
+        dimA[0] = miniBatch;
+        dimA[1] = hiddenSize;
+        dimA[2] = 1;
+
+        strideA[0] = dimA[2] * dimA[1];
+        strideA[1] = dimA[2];
+        strideA[2] = 1;
+
+        cudnnErrCheck(cudnnSetTensorNdDescriptor(yDesc[i], CUDNN_DATA_FLOAT, 3, dimA, strideA));
+    }
+
+
+    dimA[0] = numLayers;
+    dimA[1] = miniBatch;
+    dimA[2] = hiddenSize;
+
+    strideA[0] = dimA[2] * dimA[1];
+    strideA[1] = dimA[2];
+    strideA[2] = 1;
+
+    cudnnErrCheck(cudnnCreateTensorDescriptor(&hxDesc));
+    cudnnErrCheck(cudnnCreateTensorDescriptor(&cxDesc));
+    cudnnErrCheck(cudnnCreateTensorDescriptor(&hyDesc));
+    cudnnErrCheck(cudnnCreateTensorDescriptor(&cyDesc));
+
+    cudnnErrCheck(cudnnSetTensorNdDescriptor(hxDesc, CUDNN_DATA_FLOAT, 3, dimA, strideA));
+    cudnnErrCheck(cudnnSetTensorNdDescriptor(cxDesc, CUDNN_DATA_FLOAT, 3, dimA, strideA));
+    cudnnErrCheck(cudnnSetTensorNdDescriptor(hyDesc, CUDNN_DATA_FLOAT, 3, dimA, strideA));
+    cudnnErrCheck(cudnnSetTensorNdDescriptor(cyDesc, CUDNN_DATA_FLOAT, 3, dimA, strideA));
+
+    // -------------------------
+    // Set up the dropout descriptor (needed for the RNN descriptor)
+    // -------------------------
+
+    cudnnDropoutDescriptor_t dropoutDesc;
+    cudnnErrCheck(cudnnCreateDropoutDescriptor(&dropoutDesc));
+
+    size_t stateSize;
+    void *states;
+    cudnnErrCheck(cudnnDropoutGetStatesSize(cudnnHandle, &stateSize));
+
+    cudaErrCheck(cudaMalloc(&states, stateSize));
+
+    cudnnErrCheck(cudnnSetDropoutDescriptor(dropoutDesc,
+                cudnnHandle,
+                0,
+                states,
+                stateSize,
+                0));
+
+    // -------------------------
+    // Set up the RNN descriptor
+    // -------------------------
+    cudnnRNNMode_t RNNMode;
+    cudnnRNNAlgo_t RNNAlgo;
+
+    cudnnErrCheck(cudnnCreateRNNDescriptor(&rnnDesc));
+
+    RNNMode = CUDNN_LSTM;
+
+    RNNAlgo = CUDNN_RNN_ALGO_STANDARD;
+
+    cudnnErrCheck(cudnnSetRNNDescriptor_v6(cudnnHandle,
+                rnnDesc,
+                hiddenSize,
+                numLayers,
+                dropoutDesc,
+                CUDNN_LINEAR_INPUT,
+                CUDNN_UNIDIRECTIONAL,
+                RNNMode,
+                RNNAlgo,
+                CUDNN_DATA_FLOAT));
+
+
+    // -------------------------
+    // Set up parameters
+    // -------------------------
+    // This needs to be done after the rnn descriptor is set as otherwise
+    // we don't know how many parameters we have to allocate
+
+    cudnnErrCheck(cudnnCreateFilterDescriptor(&wDesc));
+
+    size_t weightsSize;
+    cudnnErrCheck(cudnnGetRNNParamsSize(cudnnHandle, rnnDesc, xDesc[0], &weightsSize, CUDNN_DATA_FLOAT));
+
+    int dimW[3];
+    dimW[0] =  weightsSize / sizeof(float);
+    dimW[1] = 1;
+    dimW[2] = 1;
+
+    cudnnErrCheck(cudnnSetFilterNdDescriptor(wDesc, CUDNN_DATA_FLOAT, CUDNN_TENSOR_NCHW, 3, dimW));
+
+    cudaErrCheck(cudaMalloc((void**)&w,  weightsSize));
+
+
+    // -------------------------
+    // Set up work space and reserved memory
+    // -------------------------
+
+    // Need for every pass
+    cudnnErrCheck(cudnnGetRNNWorkspaceSize(cudnnHandle, rnnDesc, seqLength, xDesc, &workSize));
+    cudaErrCheck(cudaMalloc((void**)&workspace, workSize));
+
+    // *********************************************************************************************************
+    // Initialise weights and inputs
+    // *********************************************************************************************************
+    // We initialise to something simple.
+    // Matrices are initialised to 1 / matrixSize, biases to 1, data is 1.
+    // initGPUData((float*)x, seqLength * inputSize * miniBatch, 1.f);
+    // if (hx != NULL) initGPUData((float*)hx, numLayers * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
+    // if (cx != NULL) initGPUData((float*)cx, numLayers * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
+
+    // initGPUData((float*)dy, seqLength * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
+    // if (dhy != NULL) initGPUData((float*)dhy, numLayers * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
+    // if (dcy != NULL) initGPUData((float*)dcy, numLayers * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
+
+
+    // Weights
+    int numLinearLayers = 8;
+
+    for (int layer = 0; layer < numLayers; layer++) {
+        for (int linLayerID = 0; linLayerID < numLinearLayers; linLayerID++) {
+            cudnnFilterDescriptor_t linLayerMatDesc;
+            cudnnErrCheck(cudnnCreateFilterDescriptor(&linLayerMatDesc));
+            float *linLayerMat;
+
+            cudnnErrCheck(cudnnGetRNNLinLayerMatrixParams( cudnnHandle,
+                        rnnDesc,
+                        layer,
+                        xDesc[0],
+                        wDesc,
+                        w,
+                        linLayerID,
+                        linLayerMatDesc,
+                        (void**)&linLayerMat));
+
+            cudnnDataType_t dataType;
+            cudnnTensorFormat_t format;
+            int nbDims;
+            int filterDimA[3];
+            cudnnErrCheck(cudnnGetFilterNdDescriptor(linLayerMatDesc,
+                        3,
+                        &dataType,
+                        &format,
+                        &nbDims,
+                        filterDimA));
+
+            // initGPUData(linLayerMat, filterDimA[0] * filterDimA[1] * filterDimA[2], 1.f / (float)(filterDimA[0] * filterDimA[1] * filterDimA[2]));
+
+            cudnnErrCheck(cudnnDestroyFilterDescriptor(linLayerMatDesc));
+
+            cudnnFilterDescriptor_t linLayerBiasDesc;
+            cudnnErrCheck(cudnnCreateFilterDescriptor(&linLayerBiasDesc));
+            float *linLayerBias;
+
+            cudnnErrCheck(cudnnGetRNNLinLayerBiasParams( cudnnHandle,
+                        rnnDesc,
+                        layer,
+                        xDesc[0],
+                        wDesc,
+                        w,
+                        linLayerID,
+                        linLayerBiasDesc,
+                        (void**)&linLayerBias));
+
+            cudnnErrCheck(cudnnGetFilterNdDescriptor(linLayerBiasDesc,
+                        3,
+                        &dataType,
+                        &format,
+                        &nbDims,
+                        filterDimA));
+
+            // initGPUData(linLayerBias, filterDimA[0] * filterDimA[1] * filterDimA[2], 1.f);
+
+            cudnnErrCheck(cudnnDestroyFilterDescriptor(linLayerBiasDesc));
+        }
+    }
+}
+
+float run_cudnn() {
+    cudaErrCheck(cudaDeviceSynchronize());
+
+    cudaEvent_t start, stop;
+    float timeForward;
+    cudaErrCheck(cudaEventCreate(&start));
+    cudaErrCheck(cudaEventCreate(&stop));
+
+    cudaErrCheck(cudaEventRecord(start));
+
+    cudnnErrCheck(cudnnRNNForwardInference(cudnnHandle,
+                rnnDesc,
+                seqLength,
+                xDesc,
+                x,
+                hxDesc,
+                hx,
+                cxDesc,
+                cx,
+                wDesc,
+                w,
+                yDesc,
+                y,
+                hyDesc,
+                hy,
+                cyDesc,
+                cy,
+                workspace,
+                workSize));
+
+    cudaErrCheck(cudaEventRecord(stop));
+    cudaErrCheck(cudaEventSynchronize(stop));
+    cudaErrCheck(cudaEventElapsedTime(&timeForward, start, stop));
+
+    // Make double-sure everything is finished before we copy for result checking.
+    cudaDeviceSynchronize();
+
+    return timeForward;
+}
+
+void free_cudnn() {
+    cudaFree(x);
+    cudaFree(hx);
+    cudaFree(cx);
+    cudaFree(y);
+    cudaFree(hy);
+    cudaFree(cy);
+    cudaFree(workspace);
+    cudaFree(w);
+
+    cudnnDestroy(cudnnHandle);
+}
+


### PR DESCRIPTION
Adding cudnn comparison for LSTM benchmark. It is based on RNN example here: 
https://github.com/shibashism/obj_detection/blob/master/samples/RNN/RNN_example.cu

cudnn is a lot faster even though the blog post's code was about the same speed as current Tiramisu code. From profiler it seems we there's a fast GEMM pass inside cudnn.

|              | K80   | P4   |
|-----------------|-------|------|
| Tiramisu        | 104ms | 37ms |
| Nvidia Blogpost | 61ms  | 35ms |
| cuDNN           | 6ms   | 4ms  |

Next up I'll add result comparison and see what we can do for Tiramisu GEMM.