### PR TITLE
LSTM GPU Update

### DIFF
--- a/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
@@ -56,10 +56,12 @@ int main(int argc, char **argv)
     buffer buf_matmul1_R_shr("b_m1_R_shr", {BLOCK, BLOCK}, p_float32, a_temporary);
     buffer buf_matmul1_R_prefreg("b_m1_R_prefreg", {1}, p_float32, a_temporary);  // Prefetch register
     buffer buf_matmul1_h_shr("b_m1_h_shr", {BLOCK, BLOCK}, p_float32, a_temporary);
+    buffer buf_matmul1_h_prefreg("b_m1_h_prefreg", {1}, p_float32, a_temporary);  // Prefetch register
     buffer buf_matmul1_acc("b_m1_acc", {1}, p_float32, a_temporary);
     buf_matmul1_R_shr.tag_gpu_shared();
     buf_matmul1_R_prefreg.tag_gpu_register();
     buf_matmul1_h_shr.tag_gpu_shared();
+    buf_matmul1_h_prefreg.tag_gpu_register();
     buf_matmul1_acc.tag_gpu_register();
 
     buffer buf_matmul2_W_shr("b_m2_W_shr", {BLOCK, BLOCK}, p_float32, a_temporary);
@@ -84,15 +86,18 @@ int main(int argc, char **argv)
     computation matmul1_R_prefreg_dec({m, l, k, i_merged}, allocate(buf_matmul1_R_prefreg));
     input matmul1_R_access({l, k, i_merged, j0}, p_float32); // Access workaround
     computation matmul1_R_shr_pref({m, l, k, i_merged}, matmul1_R_access(l, k, i_merged, 0));
-    computation matmul1_sync1({m, l, k, i_merged}, tiramisu::sync());
-    computation matmul1_sync2({m, l, k, i_merged, j0}, tiramisu::sync());
     computation matmul1_R_glb_to_prefreg({m, l, k, i_merged, j0}, matmul1_R_access(l, k, i_merged, j0 + 1));
     computation matmul1_R_prefreg_to_shr({m, l, k, i_merged, j0}, matmul1_R_glb_to_prefreg(m, l, k, i_merged, j0));
     input matmul1_R_shr_access({i_merged, j}, p_float32);
     computation matmul1_h_shr_dec({m, l, k, i_merged}, allocate(buf_matmul1_h_shr));
+    computation matmul1_h_prefreg_dec({m, l, k, i_merged}, allocate(buf_matmul1_h_prefreg));
     input matmul1_h_access({m, l, k, i_merged, j0}, p_float32);
-    computation matmul1_h_shr_copy({m, l, k, i_merged, j0}, matmul1_h_access(m, l, k, i_merged, j0));
+    computation matmul1_h_shr_pref({m, l, k, i_merged}, matmul1_h_access(m, l, k, i_merged, 0));
+    computation matmul1_h_glb_to_prefreg({m, l, k, i_merged, j0}, matmul1_h_access(m, l, k, i_merged, j0 + 1));
+    computation matmul1_h_prefreg_to_shr({m, l, k, i_merged, j0}, matmul1_h_glb_to_prefreg(m, l, k, i_merged, j0));
     input matmul1_h_shr_access({k, j}, p_float32);
+    computation matmul1_sync1({m, l, k, i_merged}, tiramisu::sync());
+    computation matmul1_sync2({m, l, k, i_merged, j0}, tiramisu::sync());
     computation matmul1_acc_dec({m, l, k, i_merged}, allocate(buf_matmul1_acc));
     computation matmul1_acc_init({m, l, k, i_merged}, (float) 0);
     computation matmul1_acc({m, l, k, i_merged, j}, matmul1_acc_init(m, l, k, i_merged)
@@ -161,7 +166,12 @@ int main(int argc, char **argv)
     matmul1_R_prefreg_to_shr.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
     matmul1_R_prefreg_to_shr.add_predicate(j0 < (feature_size - 1) / BLOCK);
     matmul1_h_shr_dec.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
-    matmul1_h_shr_copy.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
+    matmul1_h_prefreg_dec.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
+    matmul1_h_shr_pref.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
+    matmul1_h_glb_to_prefreg.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
+    matmul1_h_glb_to_prefreg.add_predicate(j0 < (feature_size - 1) / BLOCK);
+    matmul1_h_prefreg_to_shr.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
+    matmul1_h_prefreg_to_shr.add_predicate(j0 < (feature_size - 1) / BLOCK);
     matmul1_sync1.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
     matmul1_sync2.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
     matmul1_acc_dec.gpu_tile(k, i_merged, BLOCK, BLOCK, k0, i0, k1, i1);
@@ -202,14 +212,17 @@ int main(int argc, char **argv)
         .then(matmul1_R_shr_dec, i1)
         .then(matmul1_R_prefreg_dec, i1)
         .then(matmul1_h_shr_dec, i1)
+        .then(matmul1_h_prefreg_dec, i1)
         .then(matmul1_acc_init, i1)
         .then(matmul1_R_shr_pref, i1)
+        .then(matmul1_h_shr_pref, i1)
         .then(matmul1_sync1, i1)
         .then(matmul1_R_glb_to_prefreg, i1)
-        .then(matmul1_h_shr_copy, j0)
+        .then(matmul1_h_glb_to_prefreg, j0)
         .then(matmul1_acc, j0)
         .then(matmul1_sync2, j0)
         .then(matmul1_R_prefreg_to_shr, j0)
+        .then(matmul1_h_prefreg_to_shr, j0)
         .then(matmul1, i1)
         .then(matmul2_acc_dec, l)
         .then(matmul2_W_shr_dec, i1)
@@ -250,7 +263,9 @@ int main(int argc, char **argv)
     matmul1_R_prefreg_to_shr.store_in(&buf_matmul1_R_shr, {i_merged % BLOCK, k % BLOCK});
     matmul1_R_shr_access.store_in(&buf_matmul1_R_shr, {i_merged % BLOCK, j % BLOCK});
     matmul1_h_access.store_in(&buf_h, {m - 1, l, k, j0 * BLOCK + i_merged % BLOCK});
-    matmul1_h_shr_copy.store_in(&buf_matmul1_h_shr, {k % BLOCK, i_merged % BLOCK});
+    matmul1_h_shr_pref.store_in(&buf_matmul1_h_shr, {k % BLOCK, i_merged % BLOCK});
+    matmul1_h_glb_to_prefreg.store_in(&buf_matmul1_h_prefreg, {0});
+    matmul1_h_prefreg_to_shr.store_in(&buf_matmul1_h_shr, {k % BLOCK, i_merged % BLOCK});
     matmul1_h_shr_access.store_in(&buf_matmul1_h_shr, {k % BLOCK, j % BLOCK});
     matmul1_acc_init.store_in(&buf_matmul1_acc, {0});
     matmul1_acc.store_in(&buf_matmul1_acc, {0});

--- a/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
@@ -20,19 +20,46 @@ int main(int argc, char *argv[])
     int num_layers = 4;
     int seq_length = 10;
 
+    // Raw inputs
+    float *raw_Weights = (float*) malloc(feature_size * 4 * feature_size * 2 * num_layers * sizeof(float));
+    float *raw_biases = (float*) malloc(4 * feature_size * num_layers * sizeof(float));
+    float *raw_x = (float*) malloc(feature_size * batch_size * seq_length * sizeof(float));
+
+    // Initialize inputs
+    // TODO: Test correctness with non-zero inputs
+    for (int i = 0; i < num_layers; i++) {
+        for (int j = 0; j < 2; j++) {
+            for (int k = 0; k < 4 * feature_size; k++) {
+                for (int l = 0; l < feature_size; l++) {
+                    raw_Weights[((i * 2 + j) * 4 * feature_size + k) * feature_size + l] = 0;
+                }
+            }
+        }
+    }
+    for (int i = 0; i < num_layers; i++) {
+        for (int j = 0; j < 4 * feature_size; j++) {
+            raw_biases[i * 4 * feature_size + j] = 0;
+        }
+    }
+    for (int i = 0; i < seq_length; i++) {
+        for (int j = 0; j < batch_size; j++) {
+            for (int k = 0; k < feature_size; k++) {
+                raw_Weights[(i * batch_size + j) * feature_size + k] = 0;
+            }
+        }
+    }
+
     // Note that indices are flipped (see tutorial 2)
     Halide::Buffer<int32_t> buf_params(4);
-    Halide::Buffer<float> buf_Weights(feature_size, 4 * feature_size, 2, num_layers);
-    Halide::Buffer<float> buf_biases(4 * feature_size, num_layers);
-    Halide::Buffer<float> buf_x(feature_size, batch_size, seq_length);
+    Halide::Buffer<float> buf_Weights(raw_Weights, {feature_size, 4 * feature_size, 2, num_layers});
+    Halide::Buffer<float> buf_biases(raw_biases, {4 * feature_size, num_layers});
+    Halide::Buffer<float> buf_x(raw_x, {feature_size, batch_size, seq_length});
     Halide::Buffer<float> buf_y(feature_size, batch_size, seq_length);
 
     buf_params(0) = feature_size;
     buf_params(1) = batch_size;
     buf_params(2) = num_layers;
     buf_params(3) = seq_length;
-
-    // TODO: Initialize inputs
 
     for (int i = 0; i < warmupN; i++) {
         lstm(buf_params.raw_buffer(),
@@ -58,7 +85,7 @@ int main(int argc, char *argv[])
 
     std::cout << "LSTM done" << std::endl;
 
-    setup_cudnn(seq_length, num_layers, batch_size, feature_size);
+    setup_cudnn(seq_length, num_layers, batch_size, feature_size, raw_Weights, raw_biases, raw_x);
 
     std::vector<duration_t> cudnn_durations;
     for (int i = 0; i < testN; i++) {

--- a/benchmarks/DNN/blocks/LSTM/gpu/wrapper_cudnn.h
+++ b/benchmarks/DNN/blocks/LSTM/gpu/wrapper_cudnn.h
@@ -39,7 +39,8 @@ cudnnFilterDescriptor_t wDesc;
 void *workspace;
 size_t workSize;
 
-void setup_cudnn(int _seqLength, int numLayers, int batch_size, int feature_size) {
+void setup_cudnn(int _seqLength, int numLayers, int batch_size, int feature_size,
+        float *raw_Weights, float *raw_biases, float *raw_x) {
     seqLength = _seqLength;
     int hiddenSize = feature_size;
     int inputSize = hiddenSize;
@@ -54,12 +55,7 @@ void setup_cudnn(int _seqLength, int numLayers, int batch_size, int feature_size
     // Set up inputs and outputs
     // -------------------------
     cudaErrCheck(cudaMalloc((void**)&x, seqLength * inputSize * miniBatch * sizeof(float)));
-    cudaErrCheck(cudaMalloc((void**)&hx, numLayers * hiddenSize * miniBatch * sizeof(float)));
-    cudaErrCheck(cudaMalloc((void**)&cx, numLayers * hiddenSize * miniBatch * sizeof(float)));
-
     cudaErrCheck(cudaMalloc((void**)&y, seqLength * hiddenSize * miniBatch * sizeof(float)));
-    cudaErrCheck(cudaMalloc((void**)&hy, numLayers * hiddenSize * miniBatch * sizeof(float)));
-    cudaErrCheck(cudaMalloc((void**)&cy, numLayers * hiddenSize * miniBatch * sizeof(float)));
 
     xDesc = (cudnnTensorDescriptor_t*)malloc(seqLength * sizeof(cudnnTensorDescriptor_t));
     yDesc = (cudnnTensorDescriptor_t*)malloc(seqLength * sizeof(cudnnTensorDescriptor_t));
@@ -185,18 +181,9 @@ void setup_cudnn(int _seqLength, int numLayers, int batch_size, int feature_size
     cudaErrCheck(cudaMalloc((void**)&workspace, workSize));
 
     // *********************************************************************************************************
-    // Initialise weights and inputs
+    // Initialise inputs
     // *********************************************************************************************************
-    // We initialise to something simple.
-    // Matrices are initialised to 1 / matrixSize, biases to 1, data is 1.
     // initGPUData((float*)x, seqLength * inputSize * miniBatch, 1.f);
-    // if (hx != NULL) initGPUData((float*)hx, numLayers * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
-    // if (cx != NULL) initGPUData((float*)cx, numLayers * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
-
-    // initGPUData((float*)dy, seqLength * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
-    // if (dhy != NULL) initGPUData((float*)dhy, numLayers * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
-    // if (dcy != NULL) initGPUData((float*)dcy, numLayers * hiddenSize * miniBatch * (bidirectional ? 2 : 1), 1.f);
-
 
     // Weights
     int numLinearLayers = 8;
@@ -302,11 +289,7 @@ float run_cudnn() {
 
 void free_cudnn() {
     cudaFree(x);
-    cudaFree(hx);
-    cudaFree(cx);
     cudaFree(y);
-    cudaFree(hy);
-    cudaFree(cy);
     cudaFree(workspace);
     cudaFree(w);
 


### PR DESCRIPTION
Fixing some shared memory issues, changing tile size, and add prefetching for one of the matrix multiplications. On a P4, memory and tile size reduces matrix multiplication time from ~350ms to ~250ms, the total LSTM time reduction is from ~37ms to ~34ms. Prefetching gives a marginal improvement. I'm working on register prefetching and memory patterns now.

Also added some boilerplate for correctness check.