### PR TITLE
Cuda codegen cast fix

### DIFF
--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -386,9 +386,14 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
                         return statement_ptr{
                                 new function_call{tiramisu_expr.get_data_type(), tiramisu_expr.get_name(), operands}};
                     }
-                    case o_cast:
-                        return statement_ptr {new cuda_ast::cast{tiramisu_expr.get_data_type(),
-                                                                 parse_tiramisu(tiramisu_expr.get_operand(0))}};
+                    case o_cast: {
+                        if (tiramisu_expr.get_data_type() != tiramisu_expr.get_operand(0).get_data_type()) {
+                            return statement_ptr{new cuda_ast::cast{tiramisu_expr.get_data_type(),
+                                parse_tiramisu(tiramisu_expr.get_operand(0))}};
+                        } else {
+                            return parse_tiramisu(tiramisu_expr.get_operand(0));
+                        }
+                    }
                     case o_allocate:
                     {
                         auto buffer = get_buffer(tiramisu_expr.get_name());

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -387,6 +387,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
                                 new function_call{tiramisu_expr.get_data_type(), tiramisu_expr.get_name(), operands}};
                     }
                     case o_cast: {
+                        // Add a cast statement only if necessary
                         if (tiramisu_expr.get_data_type() != tiramisu_expr.get_operand(0).get_data_type()) {
                             return statement_ptr{new cuda_ast::cast{tiramisu_expr.get_data_type(),
                                 parse_tiramisu(tiramisu_expr.get_operand(0))}};


### PR DESCRIPTION
For some reason AST generates unnecessary casts like:
```
uint32_t x;
y = (uint32_t) x;
```
which makes generated CUDA code cluttered and hard to understand. Adding an if statement to check whether soruce and destination types are different. We might want to fix this in AST generation as well.

Tested on several GPU benchmarks including ones that have explicit casting.