### PR TITLE
LSTM Global memory coalescing

### DIFF
--- a/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
@@ -265,10 +265,10 @@ int main(int argc, char **argv)
     matmul1_R_glb_to_prefreg.store_in(&buf_matmul1_R_prefreg, {0});
     matmul1_R_prefreg_to_shr.store_in(&buf_matmul1_R_shr, {i_merged % BLOCK, k % BLOCK});
     matmul1_R_shr_access.store_in(&buf_matmul1_R_shr, {i_merged % BLOCK, j % BLOCK});
-    matmul1_h_access.store_in(&buf_h, {m - 1, l, k, j0 * BLOCK + i_merged % BLOCK});
-    matmul1_h_shr_pref.store_in(&buf_matmul1_h_shr, {k % BLOCK, i_merged % BLOCK});
+    matmul1_h_access.store_in(&buf_h, {m - 1, l, k - k % BLOCK + i_merged % BLOCK, j0 * BLOCK + k % BLOCK});
+    matmul1_h_shr_pref.store_in(&buf_matmul1_h_shr, {i_merged % BLOCK, k % BLOCK});
     matmul1_h_glb_to_prefreg.store_in(&buf_matmul1_h_prefreg, {0});
-    matmul1_h_prefreg_to_shr.store_in(&buf_matmul1_h_shr, {k % BLOCK, i_merged % BLOCK});
+    matmul1_h_prefreg_to_shr.store_in(&buf_matmul1_h_shr, {i_merged % BLOCK, k % BLOCK});
     matmul1_h_shr_access.store_in(&buf_matmul1_h_shr, {k % BLOCK, j % BLOCK});
     matmul1_acc_init.store_in(&buf_matmul1_acc, {0});
     matmul1_acc.store_in(&buf_matmul1_acc, {0});
@@ -277,8 +277,8 @@ int main(int argc, char **argv)
     matmul2_W_access.store_in(&buf_Weights_gpu, {l, 1, i_merged, j0 * BLOCK + k % BLOCK});
     matmul2_W_shr_copy.store_in(&buf_matmul2_W_shr, {i_merged % BLOCK, k % BLOCK});
     matmul2_W_shr_access.store_in(&buf_matmul2_W_shr, {i_merged % BLOCK, j % BLOCK});
-    matmul2_h_access.store_in(&buf_h, {m, l - 1, k, j0 * BLOCK + i_merged % BLOCK});
-    matmul2_h_shr_copy.store_in(&buf_matmul2_h_shr, {k % BLOCK, i_merged % BLOCK});
+    matmul2_h_access.store_in(&buf_h, {m, l - 1, k - k % BLOCK + i_merged % BLOCK, j0 * BLOCK + k % BLOCK});
+    matmul2_h_shr_copy.store_in(&buf_matmul2_h_shr, {i_merged % BLOCK, k % BLOCK});
     matmul2_h_shr_access.store_in(&buf_matmul2_h_shr, {k % BLOCK, j % BLOCK});
     matmul2_acc_init.store_in(&buf_matmul2_acc, {0});
     matmul2_acc.store_in(&buf_matmul2_acc, {0});

--- a/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
     computation copy_y_to_host({}, memcpy(buf_y_gpu, buf_y));
 
     // Block dimension derivation causes a bug
-    // global::get_implicit_function()->add_context_constraints("[feature_size, batch_size]->{:feature_size % 16 = 0 and batch_size % 16 = 0}");
+    global::get_implicit_function()->add_context_constraints("[feature_size, batch_size]->{:feature_size % 16 = 0 and batch_size % 16 = 0}");
 
     // -------------------------------------------------------
     // Layer II

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -386,9 +386,14 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
                         return statement_ptr{
                                 new function_call{tiramisu_expr.get_data_type(), tiramisu_expr.get_name(), operands}};
                     }
-                    case o_cast:
-                        return statement_ptr {new cuda_ast::cast{tiramisu_expr.get_data_type(),
-                                                                 parse_tiramisu(tiramisu_expr.get_operand(0))}};
+                    case o_cast: {
+                        if (tiramisu_expr.get_data_type() != tiramisu_expr.get_operand(0).get_data_type()) {
+                            return statement_ptr{new cuda_ast::cast{tiramisu_expr.get_data_type(),
+                                parse_tiramisu(tiramisu_expr.get_operand(0))}};
+                        } else {
+                            return parse_tiramisu(tiramisu_expr.get_operand(0));
+                        }
+                    }
                     case o_allocate:
                     {
                         auto buffer = get_buffer(tiramisu_expr.get_name());

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -387,6 +387,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
                                 new function_call{tiramisu_expr.get_data_type(), tiramisu_expr.get_name(), operands}};
                     }
                     case o_cast: {
+                        // Add a cast statement only if necessary
                         if (tiramisu_expr.get_data_type() != tiramisu_expr.get_operand(0).get_data_type()) {
                             return statement_ptr{new cuda_ast::cast{tiramisu_expr.get_data_type(),
                                 parse_tiramisu(tiramisu_expr.get_operand(0))}};

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -222,6 +222,8 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         isl_ast_expr_ptr value{isl_ast_expr_get_op_arg(expr.get(), 1)};
         if (expr_type == isl_ast_op_lt) {
             DEBUG(3, tiramisu::str_dump("not supported"));
+            // Even though this is "not supported", this case happens with block dimensions sometimes.
+            // cuda_ast expects loop ranges to be inclusive so we adjust the value by subtracting 1.
             cuda_ast::statement_ptr stmt = cuda_stmt_handle_isl_expr(value, node);
             return statement_ptr{new binary{stmt->get_type(),
                 stmt,

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -220,15 +220,16 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         auto expr_type = isl_ast_expr_get_op_type(expr.get());
         assert(expr_type == isl_ast_op_type::isl_ast_op_lt || expr_type == isl_ast_op_type::isl_ast_op_le);
         isl_ast_expr_ptr value{isl_ast_expr_get_op_arg(expr.get(), 1)};
-        if (expr_type == isl_ast_op_lt)
-        {
+        if (expr_type == isl_ast_op_lt) {
             DEBUG(3, tiramisu::str_dump("not supported"));
-            return cuda_stmt_handle_isl_expr(value, node);
-        } else
-        {
+            cuda_ast::statement_ptr stmt = cuda_stmt_handle_isl_expr(value, node);
+            return statement_ptr{new binary{stmt->get_type(),
+                stmt,
+                statement_ptr{new cuda_ast::value{value_cast(stmt->get_type(), 1)}},
+                "-"}};
+        } else {
             return cuda_stmt_handle_isl_expr(value, node);
         }
-
     }
 
     cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_for(isl_ast_node *node) {
@@ -486,8 +487,8 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         } else {
             actual_bound = upper_bound;
         }
-        gpu_iterator result{type, dim,  statement_ptr{new binary{actual_bound->get_type(),
-                                                                 actual_bound,
+        gpu_iterator result{type, dim, statement_ptr{new binary{actual_bound->get_type(),
+                                                                actual_bound,
                                                                 statement_ptr{new value{value_cast(actual_bound->get_type(), 1)}},
                                                                 "+"}}};
         if (min_cap.first) {


### PR DESCRIPTION
Adding global memory coalescing for LSTM. This gives significant improvement on K80 (20%), while marginal change on P4 (5%).

Note that first four commits are from previous pull request so please merge them first.