### PR TITLE
LSTM Correctness progress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,11 +359,11 @@ foreach(t ${TIRAMISU_USERS_TUTORIALS})
     new_users_tutorial(${t})
 endforeach()
 
-# TODO(akkas): Add a systematic way to add subdirectories
 if (${USE_GPU})
     add_subdirectory(benchmarks/linear_algebra/blas/level3/sgemm/gpu)
     add_subdirectory(benchmarks/linear_algebra/chain_mm/gpu)
-    add_subdirectory(benchmarks/DNN/blocks/LSTM/gpu)
+    # Disable by default since it requires cudnn
+    # add_subdirectory(benchmarks/DNN/blocks/LSTM/gpu)
 endif()
 add_subdirectory(benchmarks/DNN/layers/convolution/direct/cpu)
 add_subdirectory(benchmarks/DNN/layers/bn)

--- a/benchmarks/DNN/blocks/LSTM/cpu/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/cpu/generator.cpp
@@ -146,9 +146,9 @@ int main(int argc, char **argv)
     tnh_c.store_in(&buf_tmp_i, {k, i});
     h.store_in(&buf_h, {m + 1, l + 1, k, i});
     c.store_in(&buf_c, {m + 1, l, k, i});
-    h_init.store_in(&buf_h, {0, l, k, i});
+    h_init.store_in(&buf_h, {0, l + 1, k, i});
     c_init.store_in(&buf_c, {0, l, k, i});
-    h_copy_x.store_in(&buf_h, {m, 0, k, i});
+    h_copy_x.store_in(&buf_h, {m + 1, 0, k, i});
 
     // -------------------------------------------------------
     // Code Generation

--- a/benchmarks/DNN/blocks/LSTM/cpu/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/cpu/wrapper.cpp
@@ -29,7 +29,30 @@ int main(int argc, char *argv[])
     buf_params(2) = num_layers;
     buf_params(3) = seq_length;
 
-    // TODO: Initialize inputs
+    std::srand(0);
+    for (int i = 0; i < num_layers; i++) {
+        for (int j = 0; j < 8; j++) {
+            for (int k = 0; k < feature_size; k++) {
+                for (int l = 0; l < feature_size; l++) {
+                    buf_Weights(l, k, j, i) = (std::rand() % 200 - 100) / 100.;
+                }
+            }
+        }
+    }
+    for (int i = 0; i < num_layers; i++) {
+        for (int j = 0; j < 4; j++) {
+            for (int k = 0; k < feature_size; k++) {
+                buf_biases(k, j, i) = (std::rand() % 200 - 100) / 100.;
+            }
+        }
+    }
+    for (int i = 0; i < seq_length; i++) {
+        for (int j = 0; j < batch_size; j++) {
+            for (int k = 0; k < feature_size; k++) {
+                buf_x(k, j, i) = (std::rand() % 200 - 100) / 100.;
+            }
+        }
+    }
 
     for (int i = 0; i < warmupN; i++) {
         lstm(buf_params.raw_buffer(),

--- a/benchmarks/DNN/blocks/LSTM/gpu/CMakeLists.txt
+++ b/benchmarks/DNN/blocks/LSTM/gpu/CMakeLists.txt
@@ -2,6 +2,8 @@ set(benchmark_name benchmark_lstm_gpu)
 set(generator_name ${benchmark_name}_generator)
 set(wrapper_name ${benchmark_name}_wrapper)
 set(object_files lstm.o lstm.o_gpu.o lstm.o_cpu.o)
+set(ref_generator_name ${benchmark_name}_ref_generator)
+set(ref_object_files lstm_ref.o)
 set(cudnn_location /data/scratch/akkas/cudnn7) # Change with the cudnn library location
 #set(gemm_generator_name ${benchmark_name}_gemm_generator)
 #set(gemm_object_files gemm.o gemm.o_gpu.o gemm.o_cpu.o)
@@ -10,12 +12,16 @@ add_executable(${generator_name} generator.cpp)
 target_link_libraries(${generator_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLAGS})
 add_custom_command(OUTPUT ${object_files} COMMAND ${generator_name} DEPENDS ${generator_name})
 
+add_executable(${ref_generator_name} reference_generator.cpp)
+target_link_libraries(${ref_generator_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLAGS})
+add_custom_command(OUTPUT ${ref_object_files} COMMAND ${ref_generator_name} DEPENDS ${ref_generator_name})
+
 #add_executable(${gemm_generator_name} gemm_generator.cpp)
 #target_link_libraries(${gemm_generator_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLAGS} cuda_wrapper ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
 #add_custom_command(OUTPUT ${gemm_object_files} COMMAND ${gemm_generator_name} DEPENDS ${gemm_generator_name})
 
 find_library(cudnn cudnn PATHS ${cudnn_location}/lib64 NO_DEFAULT_PATH)
-add_executable(${wrapper_name} wrapper.cpp ${object_files})
+add_executable(${wrapper_name} wrapper.cpp ${object_files} ${ref_object_files})
 target_link_libraries(${wrapper_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLAGS} cuda_wrapper ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES} ${cudnn})
 target_include_directories(${wrapper_name} PUBLIC ${cudnn_location}/include)
 

--- a/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/generator.cpp
@@ -294,9 +294,9 @@ int main(int argc, char **argv)
     tnh_c.set_access("[feature_size] -> {tnh_c[m, l, k, i] -> buf_workspace[l, k, i + 0 * feature_size]}");
     h.store_in(&buf_h, {m + 1, l + 1, k, i});
     c.store_in(&buf_c, {m + 1, l, k, i});
-    h_init.store_in(&buf_h, {0, l, k, i});
+    h_init.store_in(&buf_h, {0, l + 1, k, i});
     c_init.store_in(&buf_c, {0, l, k, i});
-    h_copy_x.store_in(&buf_h, {m, 0, k, i});
+    h_copy_x.store_in(&buf_h, {m + 1, 0, k, i});
 
     // -------------------------------------------------------
     // Code Generation

--- a/benchmarks/DNN/blocks/LSTM/gpu/reference_generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/reference_generator.cpp
@@ -1,0 +1,162 @@
+#include <tiramisu/tiramisu.h>
+
+using namespace tiramisu;
+
+int main(int argc, char **argv)
+{
+    // Reference LSTM implementation for correctness check
+    tiramisu::init("lstm_ref");
+
+    // -------------------------------------------------------
+    // Layer I
+    // -------------------------------------------------------
+    var p_i("p_i", 0, 4);
+    input params({p_i}, p_int32);
+    constant feature_size("feature_size", params(0));
+    constant batch_size("batch_size", params(1));
+    constant num_layers("num_layers", params(2));
+    constant seq_length("seq_length", params(3));
+
+    // Inner dimensions
+    var i("i", 0, feature_size), j("j", 0, feature_size), k("k", 0, batch_size);
+    // Outer dimensions
+    var l("l", 0, num_layers), m("m", 0, seq_length);
+
+    input R_i("R_i", {l, i, j}, p_float32);
+    input R_z("R_z", {l, i, j}, p_float32);
+    input R_o("R_o", {l, i, j}, p_float32);
+    input R_f("R_f", {l, i, j}, p_float32);
+    input W_i("W_i", {l, i, j}, p_float32);
+    input W_z("W_z", {l, i, j}, p_float32);
+    input W_o("W_o", {l, i, j}, p_float32);
+    input W_f("W_f", {l, i, j}, p_float32);
+    input b_i("b_i", {l, i}, p_float32);
+    input b_z("b_z", {l, i}, p_float32);
+    input b_o("b_o", {l, i}, p_float32);
+    input b_f("b_f", {l, i}, p_float32);
+    input x({m, k, i}, p_float32);
+
+    // h(m, l) is the output of the block (m, l)
+    // which takes h(m - 1, l) and h(m, l - 1) as inputs
+    // initial hidden states are h(-1, l) and c(-1, l)
+    // input x is copied to h(m, -1)
+    computation h({m, l, k, i}, p_float32);
+    computation c({m, l, k, i}, p_float32);
+    computation h_init({l, k, i}, expr(float(0)));
+    computation c_init({l, k, i}, expr(float(0)));
+    computation h_copy_x({m, k, i}, x(m, k, i));
+    computation sum_i_init({m, l, k, i}, b_i(l, i));
+    computation sum_z_init({m, l, k, i}, b_z(l, i));
+    computation sum_o_init({m, l, k, i}, b_o(l, i));
+    computation sum_f_init({m, l, k, i}, b_f(l, i));
+    computation sum_i({m, l, k, i, j}, sum_i_init(m, l, k, i) + R_i(l, i, j) * h(m - 1, l, k, j) + W_i(l, i, j) * h(m, l - 1, k, j));
+    computation sum_z({m, l, k, i, j}, sum_z_init(m, l, k, i) + R_z(l, i, j) * h(m - 1, l, k, j) + W_z(l, i, j) * h(m, l - 1, k, j));
+    computation sum_o({m, l, k, i, j}, sum_o_init(m, l, k, i) + R_o(l, i, j) * h(m - 1, l, k, j) + W_o(l, i, j) * h(m, l - 1, k, j));
+    computation sum_f({m, l, k, i, j}, sum_f_init(m, l, k, i) + R_f(l, i, j) * h(m - 1, l, k, j) + W_f(l, i, j) * h(m, l - 1, k, j));
+    #define sigmoid(x) expr(float(1)) / (1 + expr(o_expo, -(x)))
+    computation sig_i({m, l, k, i}, sigmoid(sum_i(m, l, k, i, 0)));
+    computation tnh_z({m, l, k, i}, expr(o_tanh, sum_z(m, l, k, i, 0)));
+    computation sig_o({m, l, k, i}, sigmoid(sum_o(m, l, k, i, 0)));
+    computation sig_f({m, l, k, i}, sigmoid(sum_f(m, l, k, i, 0)));
+    computation mul_iz({m, l, k, i}, sig_i(m, l, k, i) * tnh_z(m, l, k, i));
+    computation mul_fc({m, l, k, i}, sig_f(m, l, k, i) * c(m - 1, l, k, i));
+    c.set_expression(mul_iz(m, l, k, i) + mul_fc(m, l, k, i));
+    computation tnh_c({m, l, k, i}, expr(o_tanh, c(m, l, k, i)));
+    h.set_expression(tnh_c(m, l, k, i) * sig_o(m, l, k, i));
+    // Output is the last layer
+    computation y({m, k, i}, h(m, num_layers - 1, k, i));
+
+    // -------------------------------------------------------
+    // Layer II
+    // -------------------------------------------------------
+
+    // Scheduling commands
+    h_init.then(c_init, computation::root)
+          .then(h_copy_x, computation::root)
+          .then(sum_i_init, computation::root)
+          .then(sum_z_init, l)
+          .then(sum_o_init, l)
+          .then(sum_f_init, l)
+          .then(sum_i, l)
+          .then(sum_z, l)
+          .then(sum_o, l)
+          .then(sum_f, l)
+          .then(sig_i, l)
+          .then(tnh_z, l)
+          .then(sig_o, l)
+          .then(sig_f, l)
+          .then(mul_iz, l)
+          .then(mul_fc, l)
+          .then(c, l)
+          .then(tnh_c, l)
+          .then(h, l)
+          .then(y, computation::root);
+
+    // -------------------------------------------------------
+    // Layer III
+    // -------------------------------------------------------
+
+    buffer buf_params("buf_params", {4}, p_int32, a_input);
+    buffer buf_Weights("buf_Weights", {num_layers, 2, 4 * feature_size, feature_size}, p_float32, a_input);
+    buffer buf_biases("buf_biases", {num_layers, 4 * feature_size}, p_float32, a_input);
+    buffer buf_x("buf_x", {seq_length, batch_size, feature_size}, p_float32, a_input);
+    buffer buf_y("buf_y", {seq_length, batch_size, feature_size}, p_float32, a_output);
+    buffer buf_tmp_i("buf_tmp_i", {batch_size, feature_size}, p_float32, a_temporary);
+    buffer buf_tmp_z("buf_tmp_z", {batch_size, feature_size}, p_float32, a_temporary);
+    buffer buf_tmp_o("buf_tmp_o", {batch_size, feature_size}, p_float32, a_temporary);
+    buffer buf_tmp_f("buf_tmp_f", {batch_size, feature_size}, p_float32, a_temporary);
+    buffer buf_h("buf_h", {seq_length + 1, num_layers + 1, batch_size, feature_size}, p_float32, a_temporary);
+    buffer buf_c("buf_c", {seq_length + 1, num_layers, batch_size, feature_size}, p_float32, a_temporary);
+
+    params.store_in(&buf_params);
+    // store_in workaround
+    R_i.set_access("[feature_size] -> {R_i[l, i, j] -> buf_Weights[l, 0, i + 0 * feature_size, j]}");
+    R_z.set_access("[feature_size] -> {R_z[l, i, j] -> buf_Weights[l, 0, i + 1 * feature_size, j]}");
+    R_o.set_access("[feature_size] -> {R_o[l, i, j] -> buf_Weights[l, 0, i + 2 * feature_size, j]}");
+    R_f.set_access("[feature_size] -> {R_f[l, i, j] -> buf_Weights[l, 0, i + 3 * feature_size, j]}");
+    W_i.set_access("[feature_size] -> {W_i[l, i, j] -> buf_Weights[l, 1, i + 0 * feature_size, j]}");
+    W_z.set_access("[feature_size] -> {W_z[l, i, j] -> buf_Weights[l, 1, i + 1 * feature_size, j]}");
+    W_o.set_access("[feature_size] -> {W_o[l, i, j] -> buf_Weights[l, 1, i + 2 * feature_size, j]}");
+    W_f.set_access("[feature_size] -> {W_f[l, i, j] -> buf_Weights[l, 1, i + 3 * feature_size, j]}");
+    b_i.set_access("[feature_size] -> {b_i[l, i] -> buf_biases[l, i + 0 * feature_size]}");
+    b_z.set_access("[feature_size] -> {b_z[l, i] -> buf_biases[l, i + 1 * feature_size]}");
+    b_o.set_access("[feature_size] -> {b_o[l, i] -> buf_biases[l, i + 2 * feature_size]}");
+    b_f.set_access("[feature_size] -> {b_f[l, i] -> buf_biases[l, i + 3 * feature_size]}");
+    x.store_in(&buf_x);
+    y.store_in(&buf_y);
+    sum_i_init.store_in(&buf_tmp_i, {k, i});
+    sum_z_init.store_in(&buf_tmp_z, {k, i});
+    sum_o_init.store_in(&buf_tmp_o, {k, i});
+    sum_f_init.store_in(&buf_tmp_f, {k, i});
+    sum_i.store_in(&buf_tmp_i, {k, i});
+    sum_z.store_in(&buf_tmp_z, {k, i});
+    sum_o.store_in(&buf_tmp_o, {k, i});
+    sum_f.store_in(&buf_tmp_f, {k, i});
+    sig_i.store_in(&buf_tmp_i, {k, i});
+    tnh_z.store_in(&buf_tmp_z, {k, i});
+    sig_o.store_in(&buf_tmp_o, {k, i});
+    sig_f.store_in(&buf_tmp_f, {k, i});
+    mul_iz.store_in(&buf_tmp_i, {k, i});
+    mul_fc.store_in(&buf_tmp_f, {k, i});
+    tnh_c.store_in(&buf_tmp_i, {k, i});
+    h.store_in(&buf_h, {m + 1, l + 1, k, i});
+    c.store_in(&buf_c, {m + 1, l, k, i});
+    h_init.store_in(&buf_h, {0, l + 1, k, i});
+    c_init.store_in(&buf_c, {0, l, k, i});
+    h_copy_x.store_in(&buf_h, {m + 1, 0, k, i});
+
+    // -------------------------------------------------------
+    // Code Generation
+    // -------------------------------------------------------
+
+    // Generate object files.
+    tiramisu::codegen({
+            &buf_params,
+            &buf_Weights,
+            &buf_biases,
+            &buf_x,
+            &buf_y,
+        }, "lstm_ref.o");
+
+    return 0;
+}

--- a/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu/wrapper.cpp
@@ -25,41 +25,67 @@ int main(int argc, char *argv[])
     float *raw_biases = (float*) malloc(4 * feature_size * num_layers * sizeof(float));
     float *raw_x = (float*) malloc(feature_size * batch_size * seq_length * sizeof(float));
 
-    // Initialize inputs
-    // TODO: Test correctness with non-zero inputs
-    for (int i = 0; i < num_layers; i++) {
-        for (int j = 0; j < 2; j++) {
-            for (int k = 0; k < 4 * feature_size; k++) {
-                for (int l = 0; l < feature_size; l++) {
-                    raw_Weights[((i * 2 + j) * 4 * feature_size + k) * feature_size + l] = 0;
-                }
-            }
-        }
-    }
-    for (int i = 0; i < num_layers; i++) {
-        for (int j = 0; j < 4 * feature_size; j++) {
-            raw_biases[i * 4 * feature_size + j] = 0;
-        }
-    }
-    for (int i = 0; i < seq_length; i++) {
-        for (int j = 0; j < batch_size; j++) {
-            for (int k = 0; k < feature_size; k++) {
-                raw_Weights[(i * batch_size + j) * feature_size + k] = 0;
-            }
-        }
-    }
-
     // Note that indices are flipped (see tutorial 2)
     Halide::Buffer<int32_t> buf_params(4);
     Halide::Buffer<float> buf_Weights(raw_Weights, {feature_size, 4 * feature_size, 2, num_layers});
     Halide::Buffer<float> buf_biases(raw_biases, {4 * feature_size, num_layers});
     Halide::Buffer<float> buf_x(raw_x, {feature_size, batch_size, seq_length});
     Halide::Buffer<float> buf_y(feature_size, batch_size, seq_length);
+    Halide::Buffer<float> buf_ref_y(feature_size, batch_size, seq_length);
 
+    // Initialize inputs
     buf_params(0) = feature_size;
     buf_params(1) = batch_size;
     buf_params(2) = num_layers;
     buf_params(3) = seq_length;
+
+    std::srand(0);
+    for (int i = 0; i < num_layers; i++) {
+        for (int j = 0; j < 2; j++) {
+            for (int k = 0; k < 4 * feature_size; k++) {
+                for (int l = 0; l < feature_size; l++) {
+                    buf_Weights(l, k, j, i) = (std::rand() % 200 - 100) / 100.;
+                }
+            }
+        }
+    }
+    for (int i = 0; i < num_layers; i++) {
+        for (int j = 0; j < 4 * feature_size; j++) {
+            buf_biases(j, i) = (std::rand() % 200 - 100) / 100.;
+        }
+    }
+    for (int i = 0; i < seq_length; i++) {
+        for (int j = 0; j < batch_size; j++) {
+            for (int k = 0; k < feature_size; k++) {
+                buf_x(k, j, i) = (std::rand() % 200 - 100) / 100.;
+            }
+        }
+    }
+
+    lstm(buf_params.raw_buffer(),
+         buf_Weights.raw_buffer(),
+         buf_biases.raw_buffer(),
+         buf_x.raw_buffer(),
+         buf_y.raw_buffer());
+
+    lstm_ref(buf_params.raw_buffer(),
+         buf_Weights.raw_buffer(),
+         buf_biases.raw_buffer(),
+         buf_x.raw_buffer(),
+         buf_ref_y.raw_buffer());
+
+    /* Todo: result mismatch
+    int nn = 0;
+    for (int i = 0; i < seq_length; i++) {
+        for (int j = 0; j < batch_size; j++) {
+            for (int k = 0; k < feature_size; k++) {
+                if (buf_y(k, j, i) != buf_ref_y(k, j, i) && nn++ < 100) {
+                    std::cout << i << " " << j << " " << k << " " << buf_y(k, j, i) << " " << buf_ref_y(k, j, i) << std::endl;
+                }
+            }
+        }
+    }
+    */
 
     for (int i = 0; i < warmupN; i++) {
         lstm(buf_params.raw_buffer(),

--- a/benchmarks/DNN/blocks/LSTM/gpu/wrapper.h
+++ b/benchmarks/DNN/blocks/LSTM/gpu/wrapper.h
@@ -9,6 +9,12 @@ int lstm(halide_buffer_t *b1,
          halide_buffer_t *b4,
          halide_buffer_t *b5);
 
+int lstm_ref(halide_buffer_t *b1,
+         halide_buffer_t *b2,
+         halide_buffer_t *b3,
+         halide_buffer_t *b4,
+         halide_buffer_t *b5);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
Adding reference implementation for correctness check of LSTM gpu. Also fixing an off-by-one error. There is a race condition in current gpu implementation and thus correctness check don't pass. Will fix it soon.

Also disabling LSTM by default since Cmake fails on systems with cuda but no cudnn.