### PR TITLE
cuda_ast formatting

### DIFF
--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/CMakeLists.txt
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(benchmark_name benchmark_lstm_gpu_lib)
 set(generator_name ${benchmark_name}_generator)
 set(wrapper_name ${benchmark_name}_wrapper)
-set(object_files lstm.o)# lstm.o_gpu.o lstm.o_cpu.o)
+set(object_files lstm.o lstm.o_gpu.o lstm.o_cpu.o)
 set(ref_generator_name ${benchmark_name}_ref_generator)
 set(ref_object_files lstm_ref.o)
 set(cudnn_location /data/scratch/akkas/cudnn7) # Change with the cudnn library location

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/generator.cpp
@@ -16,6 +16,7 @@ int main(int argc, char **argv)
     // Inner dimensions
     var i("i", 0, FEATURE_SIZE), j("j", 0, FEATURE_SIZE), k("k", 0, BATCH_SIZE);
     var i_merged("i_merged", 0, 4 * FEATURE_SIZE);
+    var i0("i0"), i1("i1"), k0("k0"), k1("k1");
     // Outer dimensions
     var l("l", 0, NUM_LAYERS), m("m", 0, SEQ_LENGTH);
 
@@ -24,9 +25,32 @@ int main(int argc, char **argv)
     input b("b", {l, i_merged}, p_float32);
     input x({m, k, i}, p_float32);
 
-    buffer buf_tmp("buf_tmp", {BATCH_SIZE, 4 * FEATURE_SIZE}, p_float32, a_temporary);
-    buffer buf_Weights("buf_Weights", {NUM_LAYERS, 2, 4 * FEATURE_SIZE, FEATURE_SIZE}, p_float32, a_input);
+    buffer buf_Weights_cpu("buf_Weights_cpu", {NUM_LAYERS, 2, 4 * FEATURE_SIZE, FEATURE_SIZE}, p_float32, a_input);
+    buffer buf_Weights("buf_Weights", {NUM_LAYERS, 2, 4 * FEATURE_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_h("buf_h", {SEQ_LENGTH + 1, NUM_LAYERS + 1, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_tmp("buf_tmp", {BATCH_SIZE, 4 * FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_biases_cpu("buf_biases_cpu", {NUM_LAYERS, 4 * FEATURE_SIZE}, p_float32, a_input);
+    buffer buf_x_cpu("buf_x_cpu", {SEQ_LENGTH, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_input);
+    buffer buf_y_cpu("buf_y_cpu", {SEQ_LENGTH, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_output);
+    buffer buf_biases("buf_biases", {NUM_LAYERS, 4 * FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_x("buf_x", {SEQ_LENGTH, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_y("buf_y", {SEQ_LENGTH, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_tmp_i("buf_tmp_i", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_tmp_z("buf_tmp_z", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_tmp_o("buf_tmp_o", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_tmp_f("buf_tmp_f", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_c("buf_c", {SEQ_LENGTH + 1, NUM_LAYERS, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buf_Weights.tag_gpu_global();
+    buf_h.tag_gpu_global();
+    buf_tmp.tag_gpu_global();
+    buf_biases.tag_gpu_global();
+    buf_x.tag_gpu_global();
+    buf_y.tag_gpu_global();
+    buf_tmp_i.tag_gpu_global();
+    buf_tmp_z.tag_gpu_global();
+    buf_tmp_o.tag_gpu_global();
+    buf_tmp_f.tag_gpu_global();
+    buf_c.tag_gpu_global();
 
     // h(m, l) is the output of the block (m, l)
     // which takes h(m - 1, l) and h(m, l - 1) as inputs
@@ -52,45 +76,45 @@ int main(int argc, char **argv)
     h.set_expression(tnh_c(m, l, k, i) * sig_o(m, l, k, i));
     // Output is the last layer
     computation y({m, k, i}, h(m, NUM_LAYERS - 1, k, i));
+    // Copies
+    computation copy_Weights_to_device({}, memcpy(buf_Weights_cpu, buf_Weights));
+    computation copy_biases_to_device({}, memcpy(buf_biases_cpu, buf_biases));
+    computation copy_x_to_device({}, memcpy(buf_x_cpu, buf_x));
+    computation copy_y_to_host({}, memcpy(buf_y, buf_y_cpu));
 
     // -------------------------------------------------------
     // Layer II
     // -------------------------------------------------------
 
-    // TODO: Add tiling and better schedule
+    block({&h_init, &c_init, &h_copy_x, &sig_i, &tnh_z, &sig_o, &sig_f, &mul_iz,
+           &mul_fc, &c, &tnh_c, &h, &y}).gpu_tile(k, i, 16, 16, k0, i0, k1, i1);
+    block({&sum_init, &sum1, &sum2}).gpu_tile(k, i_merged, 16, 16, k0, i0, k1, i1);
 
     // Scheduling commands
-    h_init.then(c_init, computation::root)
-          .then(h_copy_x, computation::root)
-          .then(sum_init, computation::root)
-          .then(sum1, l)
-          .then(sum2, l)
-          .then(sig_i, l)
-          .then(tnh_z, l)
-          .then(sig_o, l)
-          .then(sig_f, l)
-          .then(mul_iz, l)
-          .then(mul_fc, l)
-          .then(c, l)
-          .then(tnh_c, l)
-          .then(h, l)
-          .then(y, computation::root);
+    copy_Weights_to_device
+            .then(copy_biases_to_device, computation::root)
+            .then(copy_x_to_device, computation::root)
+            .then(h_init, computation::root)
+            .then(c_init, computation::root)
+            .then(h_copy_x, computation::root)
+            .then(sum_init, computation::root)
+            .then(sum1, l)
+            .then(sum2, l)
+            .then(sig_i, l)
+            .then(tnh_z, l)
+            .then(sig_o, l)
+            .then(sig_f, l)
+            .then(mul_iz, l)
+            .then(mul_fc, l)
+            .then(c, l)
+            .then(tnh_c, l)
+            .then(h, l)
+            .then(y, computation::root)
+            .then(copy_y_to_host, computation::root);
 
     // -------------------------------------------------------
     // Layer III
     // -------------------------------------------------------
-
-    buffer buf_biases("buf_biases", {NUM_LAYERS, 4 * FEATURE_SIZE}, p_float32, a_input);
-    buffer buf_x("buf_x", {SEQ_LENGTH, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_input);
-    buffer buf_y("buf_y", {SEQ_LENGTH, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_output);
-    // TODO: Does not support parallel
-    buffer buf_tmp_i("buf_tmp_i", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
-    buffer buf_tmp_z("buf_tmp_z", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
-    buffer buf_tmp_o("buf_tmp_o", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
-    buffer buf_tmp_f("buf_tmp_f", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
-    // TODO: As in cuDNN LSTM example, we store every output at separate places in a huge tensor.
-    // This can be made more compact.
-    buffer buf_c("buf_c", {SEQ_LENGTH + 1, NUM_LAYERS, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
 
     // Weights and biases are packed
     R.store_in(&buf_Weights, {l, 0, i_merged, j});
@@ -120,11 +144,11 @@ int main(int argc, char **argv)
 
     // Generate object files.
     tiramisu::codegen({
-            &buf_Weights,
-            &buf_biases,
-            &buf_x,
-            &buf_y,
-        }, "lstm.o");
+            &buf_Weights_cpu,
+            &buf_biases_cpu,
+            &buf_x_cpu,
+            &buf_y_cpu,
+        }, "lstm.o", true);
 
     return 0;
 }

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/generator.cpp
@@ -24,6 +24,10 @@ int main(int argc, char **argv)
     input b("b", {l, i_merged}, p_float32);
     input x({m, k, i}, p_float32);
 
+    buffer buf_tmp("buf_tmp", {BATCH_SIZE, 4 * FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_Weights("buf_Weights", {NUM_LAYERS, 2, 4 * FEATURE_SIZE, FEATURE_SIZE}, p_float32, a_input);
+    buffer buf_h("buf_h", {SEQ_LENGTH + 1, NUM_LAYERS + 1, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+
     // h(m, l) is the output of the block (m, l)
     // which takes h(m - 1, l) and h(m, l - 1) as inputs
     // initial hidden states are h(-1, l) and c(-1, l)
@@ -34,12 +38,13 @@ int main(int argc, char **argv)
     computation c_init({l, k, i}, expr(float(0)));
     computation h_copy_x({m, k, i}, x(m, k, i));
     computation sum_init({m, l, k, i_merged}, b(l, i_merged));
-    computation sum({m, l, k, i_merged, j}, sum_init(m, l, k, i_merged) + R(l, i_merged, j) * h(m - 1, l, k, j) + W(l, i_merged, j) * h(m, l - 1, k, j));
+    computation sum1({m, l, k, i_merged, j}, sum_init(m, l, k, i_merged) + R(l, i_merged, j) * h(m - 1, l, k, j));
+    computation sum2({m, l, k, i_merged, j}, sum_init(m, l, k, i_merged) + W(l, i_merged, j) * h(m, l - 1, k, j));
     #define sigmoid(x) expr(float(1)) / (1 + expr(o_expo, -(x)))
-    computation sig_i({m, l, k, i}, sigmoid(sum(m, l, k, i, 0)));
-    computation tnh_z({m, l, k, i}, expr(o_tanh, sum(m, l, k, i + FEATURE_SIZE, 0)));
-    computation sig_o({m, l, k, i}, sigmoid(sum(m, l, k, i + 2 * FEATURE_SIZE, 0)));
-    computation sig_f({m, l, k, i}, sigmoid(sum(m, l, k, i + 3 * FEATURE_SIZE, 0)));
+    computation sig_i({m, l, k, i}, sigmoid(sum_init(m, l, k, i)));
+    computation tnh_z({m, l, k, i}, expr(o_tanh, sum_init(m, l, k, i + FEATURE_SIZE)));
+    computation sig_o({m, l, k, i}, sigmoid(sum_init(m, l, k, i + 2 * FEATURE_SIZE)));
+    computation sig_f({m, l, k, i}, sigmoid(sum_init(m, l, k, i + 3 * FEATURE_SIZE)));
     computation mul_iz({m, l, k, i}, sig_i(m, l, k, i) * tnh_z(m, l, k, i));
     computation mul_fc({m, l, k, i}, sig_f(m, l, k, i) * c(m - 1, l, k, i));
     c.set_expression(mul_iz(m, l, k, i) + mul_fc(m, l, k, i));
@@ -58,7 +63,8 @@ int main(int argc, char **argv)
     h_init.then(c_init, computation::root)
           .then(h_copy_x, computation::root)
           .then(sum_init, computation::root)
-          .then(sum, l)
+          .then(sum1, l)
+          .then(sum2, l)
           .then(sig_i, l)
           .then(tnh_z, l)
           .then(sig_o, l)
@@ -74,19 +80,16 @@ int main(int argc, char **argv)
     // Layer III
     // -------------------------------------------------------
 
-    buffer buf_Weights("buf_Weights", {NUM_LAYERS, 2, 4 * FEATURE_SIZE, FEATURE_SIZE}, p_float32, a_input);
     buffer buf_biases("buf_biases", {NUM_LAYERS, 4 * FEATURE_SIZE}, p_float32, a_input);
     buffer buf_x("buf_x", {SEQ_LENGTH, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_input);
     buffer buf_y("buf_y", {SEQ_LENGTH, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_output);
     // TODO: Does not support parallel
-    buffer buf_tmp("buf_tmp", {BATCH_SIZE, 4 * FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_tmp_i("buf_tmp_i", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_tmp_z("buf_tmp_z", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_tmp_o("buf_tmp_o", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_tmp_f("buf_tmp_f", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     // TODO: As in cuDNN LSTM example, we store every output at separate places in a huge tensor.
     // This can be made more compact.
-    buffer buf_h("buf_h", {SEQ_LENGTH + 1, NUM_LAYERS + 1, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_c("buf_c", {SEQ_LENGTH + 1, NUM_LAYERS, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
 
     // Weights and biases are packed
@@ -96,7 +99,8 @@ int main(int argc, char **argv)
     x.store_in(&buf_x);
     y.store_in(&buf_y);
     sum_init.store_in(&buf_tmp, {k, i_merged});
-    sum.store_in(&buf_tmp, {k, i_merged});
+    sum1.store_in(&buf_tmp, {k, i_merged});
+    sum2.store_in(&buf_tmp, {k, i_merged});
     sig_i.store_in(&buf_tmp_i, {k, i});
     tnh_z.store_in(&buf_tmp_z, {k, i});
     sig_o.store_in(&buf_tmp_o, {k, i});

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/reference_generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/reference_generator.cpp
@@ -44,15 +44,19 @@ int main(int argc, char **argv)
     computation sum_z_init({m, l, k, i}, b_z(l, i));
     computation sum_o_init({m, l, k, i}, b_o(l, i));
     computation sum_f_init({m, l, k, i}, b_f(l, i));
-    computation sum_i({m, l, k, i, j}, sum_i_init(m, l, k, i) + R_i(l, i, j) * h(m - 1, l, k, j) + W_i(l, i, j) * h(m, l - 1, k, j));
-    computation sum_z({m, l, k, i, j}, sum_z_init(m, l, k, i) + R_z(l, i, j) * h(m - 1, l, k, j) + W_z(l, i, j) * h(m, l - 1, k, j));
-    computation sum_o({m, l, k, i, j}, sum_o_init(m, l, k, i) + R_o(l, i, j) * h(m - 1, l, k, j) + W_o(l, i, j) * h(m, l - 1, k, j));
-    computation sum_f({m, l, k, i, j}, sum_f_init(m, l, k, i) + R_f(l, i, j) * h(m - 1, l, k, j) + W_f(l, i, j) * h(m, l - 1, k, j));
+    computation sum_i1({m, l, k, i, j}, sum_i_init(m, l, k, i) + R_i(l, i, j) * h(m - 1, l, k, j));
+    computation sum_i2({m, l, k, i, j}, sum_i_init(m, l, k, i) + W_i(l, i, j) * h(m, l - 1, k, j));
+    computation sum_z1({m, l, k, i, j}, sum_z_init(m, l, k, i) + R_z(l, i, j) * h(m - 1, l, k, j));
+    computation sum_z2({m, l, k, i, j}, sum_z_init(m, l, k, i) + W_z(l, i, j) * h(m, l - 1, k, j));
+    computation sum_o1({m, l, k, i, j}, sum_o_init(m, l, k, i) + R_o(l, i, j) * h(m - 1, l, k, j));
+    computation sum_o2({m, l, k, i, j}, sum_o_init(m, l, k, i) + W_o(l, i, j) * h(m, l - 1, k, j));
+    computation sum_f1({m, l, k, i, j}, sum_f_init(m, l, k, i) + R_f(l, i, j) * h(m - 1, l, k, j));
+    computation sum_f2({m, l, k, i, j}, sum_f_init(m, l, k, i) + W_f(l, i, j) * h(m, l - 1, k, j));
     #define sigmoid(x) expr(float(1)) / (1 + expr(o_expo, -(x)))
-    computation sig_i({m, l, k, i}, sigmoid(sum_i(m, l, k, i, 0)));
-    computation tnh_z({m, l, k, i}, expr(o_tanh, sum_z(m, l, k, i, 0)));
-    computation sig_o({m, l, k, i}, sigmoid(sum_o(m, l, k, i, 0)));
-    computation sig_f({m, l, k, i}, sigmoid(sum_f(m, l, k, i, 0)));
+    computation sig_i({m, l, k, i}, sigmoid(sum_i2(m, l, k, i, 0)));
+    computation tnh_z({m, l, k, i}, expr(o_tanh, sum_z2(m, l, k, i, 0)));
+    computation sig_o({m, l, k, i}, sigmoid(sum_o2(m, l, k, i, 0)));
+    computation sig_f({m, l, k, i}, sigmoid(sum_f2(m, l, k, i, 0)));
     computation mul_iz({m, l, k, i}, sig_i(m, l, k, i) * tnh_z(m, l, k, i));
     computation mul_fc({m, l, k, i}, sig_f(m, l, k, i) * c(m - 1, l, k, i));
     c.set_expression(mul_iz(m, l, k, i) + mul_fc(m, l, k, i));
@@ -72,10 +76,14 @@ int main(int argc, char **argv)
           .then(sum_z_init, l)
           .then(sum_o_init, l)
           .then(sum_f_init, l)
-          .then(sum_i, l)
-          .then(sum_z, l)
-          .then(sum_o, l)
-          .then(sum_f, l)
+          .then(sum_i1, l)
+          .then(sum_i2, l)
+          .then(sum_z1, l)
+          .then(sum_z2, l)
+          .then(sum_o1, l)
+          .then(sum_o2, l)
+          .then(sum_f1, l)
+          .then(sum_f2, l)
           .then(sig_i, l)
           .then(tnh_z, l)
           .then(sig_o, l)
@@ -122,10 +130,14 @@ int main(int argc, char **argv)
     sum_z_init.store_in(&buf_tmp_z, {k, i});
     sum_o_init.store_in(&buf_tmp_o, {k, i});
     sum_f_init.store_in(&buf_tmp_f, {k, i});
-    sum_i.store_in(&buf_tmp_i, {k, i});
-    sum_z.store_in(&buf_tmp_z, {k, i});
-    sum_o.store_in(&buf_tmp_o, {k, i});
-    sum_f.store_in(&buf_tmp_f, {k, i});
+    sum_i1.store_in(&buf_tmp_i, {k, i});
+    sum_i2.store_in(&buf_tmp_i, {k, i});
+    sum_z1.store_in(&buf_tmp_z, {k, i});
+    sum_z2.store_in(&buf_tmp_z, {k, i});
+    sum_o1.store_in(&buf_tmp_o, {k, i});
+    sum_o2.store_in(&buf_tmp_o, {k, i});
+    sum_f1.store_in(&buf_tmp_f, {k, i});
+    sum_f2.store_in(&buf_tmp_f, {k, i});
     sig_i.store_in(&buf_tmp_i, {k, i});
     tnh_z.store_in(&buf_tmp_z, {k, i});
     sig_o.store_in(&buf_tmp_o, {k, i});

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
@@ -55,8 +55,15 @@ int main(int argc, char *argv[])
     for (int i = 0; i < SEQ_LENGTH; i++) {
         for (int j = 0; j < BATCH_SIZE; j++) {
             for (int k = 0; k < FEATURE_SIZE; k++) {
-                if (buf_y(k, j, i) != buf_ref_y(k, j, i) && nn++ < 100) {
-                    std::cout << i << " " << j << " " << k << " " << buf_y(k, j, i) << " " << buf_ref_y(k, j, i) << std::endl;
+                float res = buf_y(k, j, i);
+                float ref = buf_ref_y(k, j, i);
+                float err = std::abs(ref - res);
+                // Relative error:
+                float rel_err = err / std::max(std::abs(res), std::abs(ref));
+                if (err > 0 && nn++ < 100) {
+                    std::cout << i << " " << j << " " << k << ": "
+                              << res << " " << ref << ", "
+                              << err << " " << rel_err << std::endl;
                 }
             }
         }

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
@@ -54,6 +54,7 @@ int main(int argc, char *argv[])
     int nn = 0;
     float max_err = 0;
     float max_rel_err = 0;
+    std::cout << "Comparing against the reference:" << std::endl;
     for (int i = 0; i < SEQ_LENGTH; i++) {
         for (int j = 0; j < BATCH_SIZE; j++) {
             for (int k = 0; k < FEATURE_SIZE; k++) {

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
@@ -52,6 +52,8 @@ int main(int argc, char *argv[])
          buf_ref_y.raw_buffer());
 
     int nn = 0;
+    float max_err = 0;
+    float max_rel_err = 0;
     for (int i = 0; i < SEQ_LENGTH; i++) {
         for (int j = 0; j < BATCH_SIZE; j++) {
             for (int k = 0; k < FEATURE_SIZE; k++) {
@@ -60,7 +62,9 @@ int main(int argc, char *argv[])
                 float err = std::abs(ref - res);
                 // Relative error:
                 float rel_err = err / std::max(std::abs(res), std::abs(ref));
-                if (err > 0 && nn++ < 100) {
+                max_err = std::max(max_err, err);
+                max_rel_err = std::max(max_rel_err, rel_err);
+                if (err > 0.01 && nn++ < 10) {
                     std::cout << i << " " << j << " " << k << ": "
                               << res << " " << ref << ", "
                               << err << " " << rel_err << std::endl;
@@ -68,6 +72,9 @@ int main(int argc, char *argv[])
             }
         }
     }
+
+    std::cout << "Max error: " << max_err << std::endl;
+    std::cout << "Max relative error: " << max_rel_err << std::endl;
 
     return 0;
     /*

--- a/include/tiramisu/core.h
+++ b/include/tiramisu/core.h
@@ -1324,6 +1324,11 @@ public:
     tiramisu::argument_t get_argument_type() const;
 
     /**
+     * Return the memory location of the buffer.
+     */
+    cuda_ast::memory_location get_location() const;
+
+    /**
       * Return the name of the buffer.
       */
     const std::string &get_name() const;

--- a/include/tiramisu/cuda_ast.h
+++ b/include/tiramisu/cuda_ast.h
@@ -35,54 +35,57 @@
 
 namespace tiramisu
 {
-    struct isl_ast_expr_deleter
-    {
-        void operator()(isl_ast_expr * p) const {isl_ast_expr_free(p);}
-    };
-    typedef std::unique_ptr<isl_ast_expr, isl_ast_expr_deleter> isl_ast_expr_ptr;
 
-    struct isl_id_deleter
-    {
-        void operator()(isl_id * p) const {isl_id_free(p);}
-    };
-    typedef std::unique_ptr<isl_id, isl_id_deleter> isl_id_ptr;
+struct isl_ast_expr_deleter
+{
+    void operator()(isl_ast_expr * p) const {isl_ast_expr_free(p);}
+};
+typedef std::unique_ptr<isl_ast_expr, isl_ast_expr_deleter> isl_ast_expr_ptr;
 
-    struct isl_ast_node_list_deleter
-    {
-        void operator()(isl_ast_node_list * p) const {isl_ast_node_list_free(p);}
-    };
-    typedef std::unique_ptr<isl_ast_node_list, isl_ast_node_list_deleter> isl_ast_node_list_ptr;
+struct isl_id_deleter
+{
+    void operator()(isl_id * p) const {isl_id_free(p);}
+};
+typedef std::unique_ptr<isl_id, isl_id_deleter> isl_id_ptr;
 
-    struct isl_val_deleter
-    {
-        void operator()(isl_val * p) const {isl_val_free(p);}
-    };
-    typedef std::unique_ptr<isl_val, isl_val_deleter> isl_val_ptr;
+struct isl_ast_node_list_deleter
+{
+    void operator()(isl_ast_node_list * p) const {isl_ast_node_list_free(p);}
+};
+typedef std::unique_ptr<isl_ast_node_list, isl_ast_node_list_deleter> isl_ast_node_list_ptr;
 
-    class function;
+struct isl_val_deleter
+{
+    void operator()(isl_val * p) const {isl_val_free(p);}
+};
+typedef std::unique_ptr<isl_val, isl_val_deleter> isl_val_ptr;
+
+class function;
+
 namespace cuda_ast
 {
-    struct op_data_t
-    {
-        op_data_t() {}
-        op_data_t(bool infix, int arity, std::string && symbol) : infix(infix), arity(arity), symbol(symbol) {}
-        op_data_t(bool infix, int arity, std::string && symbol, std::string && next_symbol) : infix(infix), arity(arity), symbol(symbol), next_symbol(next_symbol) {}
-        op_data_t(bool infix, int arity, std::string && symbol, primitive_t type) : infix(infix), arity(arity), symbol(symbol), type_preserving(
-                false), type(type) {}
-        op_data_t(bool infix, int arity, std::string && symbol, std::string && next_symbol, primitive_t type) : infix(infix), arity(arity), symbol(symbol), next_symbol(next_symbol), type_preserving(
-                false), type(type) {}
 
-        bool operator==(const op_data_t &rhs) const;
+struct op_data_t
+{
+    op_data_t() {}
+    op_data_t(bool infix, int arity, std::string && symbol) : infix(infix), arity(arity), symbol(symbol) {}
+    op_data_t(bool infix, int arity, std::string && symbol, std::string && next_symbol) : infix(infix), arity(arity), symbol(symbol), next_symbol(next_symbol) {}
+    op_data_t(bool infix, int arity, std::string && symbol, primitive_t type) : infix(infix), arity(arity), symbol(symbol), type_preserving(
+            false), type(type) {}
+    op_data_t(bool infix, int arity, std::string && symbol, std::string && next_symbol, primitive_t type) : infix(infix), arity(arity), symbol(symbol), next_symbol(next_symbol), type_preserving(
+            false), type(type) {}
 
-        bool operator!=(const op_data_t &rhs) const;
+    bool operator==(const op_data_t &rhs) const;
 
-        bool infix;
-        int arity;
-        std::string symbol;
-        std::string next_symbol = "";
-        bool type_preserving = true;
-        primitive_t type = p_none;
-    };
+    bool operator!=(const op_data_t &rhs) const;
+
+    bool infix;
+    int arity;
+    std::string symbol;
+    std::string next_symbol = "";
+    bool type_preserving = true;
+    primitive_t type = p_none;
+};
 
 const op_data_t tiramisu_operation_description(tiramisu::op_t op);
 
@@ -157,7 +160,7 @@ const op_data_t isl_operation_description(isl_ast_op_type op);
 //        BINARY_TYPED(isl_ast_op_gt, ">", p_boolean),
 //    };
 
-    const std::string tiramisu_type_to_cuda_type(tiramisu::primitive_t t);
+const std::string tiramisu_type_to_cuda_type(tiramisu::primitive_t t);
 
 
 //    const std::unordered_map <tiramisu::primitive_t, std::string> tiramisu_type_to_cuda_type = {
@@ -185,15 +188,12 @@ enum class memory_location
 };
 
 class abstract_node {
-
 };
 
-    class statement;
-    typedef std::shared_ptr<statement> statement_ptr;
+class statement;
+typedef std::shared_ptr<statement> statement_ptr;
+struct gpu_iterator;
 
-
-
-    struct gpu_iterator;
 class statement : public abstract_node {
 public:
     primitive_t get_type() const;
@@ -262,7 +262,8 @@ private:
 public:
 
 };
-    typedef std::shared_ptr<abstract_identifier> abstract_identifier_ptr;
+
+typedef std::shared_ptr<abstract_identifier> abstract_identifier_ptr;
 
 class buffer : public abstract_identifier
 {
@@ -540,9 +541,8 @@ public:
     void print(std::stringstream &ss, const std::string &base) override;
 };
 
-
-        class kernel_call;
-        class kernel_definition;
+class kernel_call;
+class kernel_definition;
 
 class return_statement : public statement
 {
@@ -552,6 +552,7 @@ public:
     explicit return_statement(statement_ptr return_value);
     void print(std::stringstream &ss, const std::string &base) override;
 };
+
 class host_function : public statement
 {
 public:
@@ -596,8 +597,8 @@ public:
     void add_used_scalar(scalar_ptr scalar);
     void add_used_buffer(buffer_ptr buffer);
     std::vector<abstract_identifier_ptr> get_arguments();
-
 };
+
 typedef std::shared_ptr<kernel> kernel_ptr;
 
 class kernel_call : public statement
@@ -631,7 +632,6 @@ private:
     buffer_ptr from, to;
 };
 
-
 class allocate : public statement
 {
 public:
@@ -651,7 +651,6 @@ public:
 private:
     buffer_ptr b;
 };
-
 
 class generator
 {
@@ -700,36 +699,36 @@ public:
 
 namespace {
 
-    struct exec_result {
-        bool exec_succeeded;
-        int result;
-        std::string std_out;
-        std::string std_err;
+struct exec_result {
+    bool exec_succeeded;
+    int result;
+    std::string std_out;
+    std::string std_err;
 
-        bool fail();
+    bool fail();
 
-        bool succeed();
-    };
-
-}
-
-    class compiler
-    {
-        std::string code;
-
-        bool compile_cpu_obj(const std::string &filename, const std::string &obj_name) const;
-        bool compile_gpu_obj(const std::string &obj_name) const;
-        static exec_result exec(const std::string &cmd);
-
-    public:
-        std::string get_cpu_obj(const std::string &obj_name) const;
-        std::string get_gpu_obj(const std::string &obj_name) const;
-        explicit compiler(const std::string &code);
-        bool compile(const std::string &obj_name) const;
-    };
+    bool succeed();
+};
 
 }
 
-}
+class compiler
+{
+    std::string code;
+
+    bool compile_cpu_obj(const std::string &filename, const std::string &obj_name) const;
+    bool compile_gpu_obj(const std::string &obj_name) const;
+    static exec_result exec(const std::string &cmd);
+
+public:
+    std::string get_cpu_obj(const std::string &obj_name) const;
+    std::string get_gpu_obj(const std::string &obj_name) const;
+    explicit compiler(const std::string &code);
+    bool compile(const std::string &obj_name) const;
+};
+
+}  // namespace cuda_ast
+
+}  // namespace tiramisu
 
 #endif //TIRAMISU_CUDA_AST_H

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -30,11 +30,11 @@
 #include <memory>
 
 namespace tiramisu {
-    tiramisu::expr replace_original_indices_with_transformed_indices(tiramisu::expr exp,
-                                                                     std::map<std::string, isl_ast_expr *> iterators_map);
-namespace cuda_ast {
 
-const tiramisu::cuda_ast::op_data_t tiramisu_operation_description(tiramisu::op_t op) {
+tiramisu::expr replace_original_indices_with_transformed_indices(tiramisu::expr exp,
+                                                                 std::map<std::string, isl_ast_expr *> iterators_map);
+
+const cuda_ast::op_data_t cuda_ast::tiramisu_operation_description(tiramisu::op_t op) {
     switch (op) {
         UNARY2(tiramisu::o_minus, "-")
         FN_CALL2(tiramisu::o_floor, "floor", 1)
@@ -79,11 +79,11 @@ const tiramisu::cuda_ast::op_data_t tiramisu_operation_description(tiramisu::op_
         FN_CALL2(tiramisu::o_lerp, "lerp", 3)
         default:
             assert(false);
-            return tiramisu::cuda_ast::op_data_t();
+            return cuda_ast::op_data_t();
     }
 }
 
-const tiramisu::cuda_ast::op_data_t isl_operation_description(isl_ast_op_type op) {
+const cuda_ast::op_data_t cuda_ast::isl_operation_description(isl_ast_op_type op) {
     switch (op) {
         BINARY_TYPED2(isl_ast_op_and, "&&", tiramisu::p_boolean)
         BINARY_TYPED2(isl_ast_op_and_then, "&&", tiramisu::p_boolean)
@@ -109,12 +109,12 @@ const tiramisu::cuda_ast::op_data_t isl_operation_description(isl_ast_op_type op
         BINARY_TYPED2(isl_ast_op_gt, ">", tiramisu::p_boolean)
         default: {
             assert(false);
-            return tiramisu::cuda_ast::op_data_t();
+            return cuda_ast::op_data_t();
         }
     }
 }
 
-const std::string tiramisu_type_to_cuda_type(tiramisu::primitive_t t) {
+const std::string cuda_ast::tiramisu_type_to_cuda_type(tiramisu::primitive_t t) {
     switch (t) {
         case tiramisu::p_none:
             return "void";
@@ -147,31 +147,26 @@ const std::string tiramisu_type_to_cuda_type(tiramisu::primitive_t t) {
     }
 }
 
-}
-}
+cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_node *node) {
+    isl_ast_node_type type = isl_ast_node_get_type(node);
 
-namespace tiramisu {
-
-cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_node *node) {
-        isl_ast_node_type type = isl_ast_node_get_type(node);
-
-        switch (type) {
-            case isl_ast_node_for:
-                return cuda_stmt_handle_isl_for(node);
-            case isl_ast_node_block:
-                return cuda_stmt_handle_isl_block(node);
-            case isl_ast_node_if:
-                return cuda_stmt_handle_isl_if(node);
-            case isl_ast_node_mark: DEBUG(3, tiramisu::str_dump("mark"));
-                return nullptr;
-            case isl_ast_node_user:
-                return cuda_stmt_handle_isl_user(node);
-            default: DEBUG(3, tiramisu::str_dump("default"));
-                return nullptr;
-        }
+    switch (type) {
+        case isl_ast_node_for:
+            return cuda_stmt_handle_isl_for(node);
+        case isl_ast_node_block:
+            return cuda_stmt_handle_isl_block(node);
+        case isl_ast_node_if:
+            return cuda_stmt_handle_isl_if(node);
+        case isl_ast_node_mark: DEBUG(3, tiramisu::str_dump("mark"));
+            return nullptr;
+        case isl_ast_node_user:
+            return cuda_stmt_handle_isl_user(node);
+        default: DEBUG(3, tiramisu::str_dump("default"));
+            return nullptr;
     }
+}
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_if(isl_ast_node *node) {
+    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_if(isl_ast_node *node) {
         isl_ast_node *then_body = isl_ast_node_if_get_then(node);
         isl_ast_expr_ptr condition{isl_ast_node_if_get_cond(node)};
 
@@ -192,7 +187,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
 
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_block(isl_ast_node *node) {
+    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_block(isl_ast_node *node) {
         isl_ast_node_list_ptr children_list{isl_ast_node_block_get_children(node)};
         const int block_length = isl_ast_node_list_n_ast_node(children_list.get());
         auto *b = new block;
@@ -204,7 +199,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
     }
 
     void
-    tiramisu::cuda_ast::generator::cuda_stmt_foreach_isl_expr_list(isl_ast_expr *node,
+    cuda_ast::generator::cuda_stmt_foreach_isl_expr_list(isl_ast_expr *node,
                                                                    const std::function<void(int, isl_ast_expr *)> &fn,
                                                                    int start) {
         int n = isl_ast_expr_get_op_n_arg(node);
@@ -213,7 +208,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         }
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_val_from_for_condition(isl_ast_expr_ptr &expr, isl_ast_node *node)
+    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_val_from_for_condition(isl_ast_expr_ptr &expr, isl_ast_node *node)
     {
         // TODO this is potentially a hack
         assert(isl_ast_expr_get_type(expr.get()) == isl_ast_expr_type::isl_ast_expr_op);
@@ -234,7 +229,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         }
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_for(isl_ast_node *node) {
+    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_for(isl_ast_node *node) {
         isl_ast_expr_ptr iterator{isl_ast_node_for_get_iterator(node)};
         isl_id_ptr iterator_id{isl_ast_expr_get_id(iterator.get())};
         std::string iterator_name(isl_id_get_name(iterator_id.get()));
@@ -327,7 +322,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         return result;
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_expr(isl_ast_expr_ptr &expr,
+    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_expr(isl_ast_expr_ptr &expr,
                                                                                      isl_ast_node *node) {
         isl_ast_expr_type type = isl_ast_expr_get_type(expr.get());
         switch (type) {
@@ -351,7 +346,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
     }
 
 
-    cuda_ast::value_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_val(isl_val_ptr &node) {
+    cuda_ast::value_ptr cuda_ast::generator::cuda_stmt_handle_isl_val(isl_val_ptr &node) {
         // TODO handle infinity
         long num = isl_val_get_num_si(node.get());
         long den = isl_val_get_den_si(node.get());
@@ -360,7 +355,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
     }
 
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::parse_tiramisu(const tiramisu::expr &tiramisu_expr) {
+    cuda_ast::statement_ptr cuda_ast::generator::parse_tiramisu(const tiramisu::expr &tiramisu_expr) {
         switch (tiramisu_expr.get_expr_type()) {
             case e_val:
                 return statement_ptr{new cuda_ast::value{tiramisu_expr}};
@@ -460,7 +455,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         }
     }
 
-    cuda_ast::buffer_ptr tiramisu::cuda_ast::generator::get_buffer(const std::string &name) {
+    cuda_ast::buffer_ptr cuda_ast::generator::get_buffer(const std::string &name) {
         auto it = m_buffers.find(name);
         cuda_ast::buffer_ptr buffer;
         if (it != m_buffers.end())
@@ -520,7 +515,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         return result;
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_op_expr(isl_ast_expr_ptr &expr,
+    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_op_expr(isl_ast_expr_ptr &expr,
                                                                                         isl_ast_node *node) {
         isl_ast_op_type op_type = isl_ast_expr_get_op_type(expr.get());
         if (op_type == isl_ast_op_call) {
@@ -709,7 +704,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         }
     }
 
-    cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_handle_isl_user(isl_ast_node *node) {
+    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_user(isl_ast_node *node) {
         isl_ast_expr_ptr expr{isl_ast_node_user_get_expr(node)};
         return cuda_stmt_handle_isl_expr(expr, node);
     }
@@ -819,7 +814,7 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         DEBUG_INDENT(-4);
     }
 
-    tiramisu::cuda_ast::generator::generator(tiramisu::function &fct) : m_fct(fct) {
+    cuda_ast::generator::generator(tiramisu::function &fct) : m_fct(fct) {
         for (const tiramisu::constant &invariant : fct.get_invariants()) {
             m_scalar_data.insert(std::make_pair(invariant.get_name(),
                                                 std::make_pair(invariant.get_data_type(),
@@ -1816,5 +1811,5 @@ cuda_ast::statement_ptr tiramisu::cuda_ast::generator::cuda_stmt_from_isl_node(i
         pointer_return = val;
     }
 
-};
+}  // namespace tiramisu
 

--- a/src/tiramisu_core.cpp
+++ b/src/tiramisu_core.cpp
@@ -5581,6 +5581,11 @@ tiramisu::argument_t buffer::get_argument_type() const
     return argtype;
 }
 
+cuda_ast::memory_location buffer::get_location() const
+{
+    return this->location;
+}
+
 /**
   * Return the name of the buffer.
   */

--- a/src/tiramisu_expr.cpp
+++ b/src/tiramisu_expr.cpp
@@ -192,6 +192,11 @@ expr cublas_sgemm(const buffer &A, const buffer &B, buffer &C,
                   expr offsetA, expr offsetB, expr offsetC,
                   expr transposeA, expr transposeB)
 {
+    if (A.get_location() != cuda_ast::memory_location::global ||
+        B.get_location() != cuda_ast::memory_location::global ||
+        C.get_location() != cuda_ast::memory_location::global) {
+        ERROR("Buffers must be on GPU global memory", true);
+    }
     if (A.get_elements_type() != p_float32 ||
         B.get_elements_type() != p_float32 ||
         C.get_elements_type() != p_float32) {


### PR DESCRIPTION
Please review https://github.com/Tiramisu-Compiler/tiramisu/pull/202 first.

Fixes some indentation issues of `cuda_ast.h`. Also simplifies namespace structure of `tiramisu_codegen_cuda.cpp`. No functionality changed. Only whitespace and namespace changes.

The half of `tiramisu_codegen_cuda.cpp` is in wrong indentation. I don't want to change it in one shot since it confuses git-diff and makes it very difficult to track changes through git-blame. I will fix indentations as I make changes to functions.

GPU tests succeed. Please wait for Travis tests to pass as well.