### PR TITLE
LSTM_cublas Optimizations

### DIFF
--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/CMakeLists.txt
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/CMakeLists.txt
@@ -20,5 +20,6 @@ target_link_libraries(${wrapper_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLA
 target_include_directories(${wrapper_name} PUBLIC ${cudnn_location}/include)
 
 add_custom_target(run_${benchmark_name} COMMAND ${wrapper_name})
-add_custom_target(run_${benchmark_name}_nvprof COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --profile-from-start off --print-gpu-trace $<TARGET_FILE:${wrapper_name}> 1 0 DEPENDS ${wrapper_name})
+add_custom_target(run_${benchmark_name}_correctness COMMAND ${wrapper_name} 0 0 0 1)
+add_custom_target(run_${benchmark_name}_nvprof COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --profile-from-start off --print-gpu-trace $<TARGET_FILE:${wrapper_name}> DEPENDS ${wrapper_name})
 add_custom_target(run_${benchmark_name}_nvprof2 COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --profile-from-start off $<TARGET_FILE:${wrapper_name}> DEPENDS ${wrapper_name})

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/configuration.h
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/configuration.h
@@ -1,4 +1,4 @@
-#define FEATURE_SIZE int32_t(512)
-#define BATCH_SIZE int32_t(64)
-#define NUM_LAYERS int32_t(4)
-#define SEQ_LENGTH int32_t(10)  // 100
+#define FEATURE_SIZE int32_t(512)  // 512
+#define BATCH_SIZE int32_t(64)  // 64
+#define NUM_LAYERS int32_t(4)  // 4
+#define SEQ_LENGTH int32_t(100)  // 100

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/generator.cpp
@@ -18,12 +18,12 @@ int main(int argc, char **argv)
     var i_merged("i_merged", 0, 4 * FEATURE_SIZE);
     var i0("i0"), i1("i1"), k0("k0"), k1("k1");
     // Outer dimensions
-    var l("l", 0, NUM_LAYERS), m("m", 0, SEQ_LENGTH);
+    var l("l", 0, NUM_LAYERS), s("s", 0, SEQ_LENGTH);
 
     input R("R", {l, i_merged, j}, p_float32);
     input W("W", {l, i_merged, j}, p_float32);
     input b("b", {l, i_merged}, p_float32);
-    input x({m, k, i}, p_float32);
+    input x({s, k, i}, p_float32);
 
     buffer buf_Weights_cpu("buf_Weights_cpu", {NUM_LAYERS, 2, 4 * FEATURE_SIZE, FEATURE_SIZE}, p_float32, a_input);
     buffer buf_Weights("buf_Weights", {NUM_LAYERS, 2, 4 * FEATURE_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
     buffer buf_tmp_z("buf_tmp_z", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_tmp_o("buf_tmp_o", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_tmp_f("buf_tmp_f", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
-    buffer buf_c("buf_c", {SEQ_LENGTH + 1, NUM_LAYERS, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_c("buf_c", {NUM_LAYERS, SEQ_LENGTH + 1, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buf_Weights.tag_gpu_global();
     buf_h.tag_gpu_global();
     buf_tmp.tag_gpu_global();
@@ -52,46 +52,47 @@ int main(int argc, char **argv)
     buf_tmp_f.tag_gpu_global();
     buf_c.tag_gpu_global();
 
-    // h(m, l) is the output of the block (m, l)
-    // which takes h(m - 1, l) and h(m, l - 1) as inputs
-    // initial hidden states are h(-1, l) and c(-1, l)
-    // input x is copied to h(m, -1)
-    computation h({m, l, k, i}, p_float32);
-    computation c({m, l, k, i}, p_float32);
+    // h(l, s) is the output of the block (l, s)
+    // which takes h(l, s - 1) and h(l - 1, s) as inputs
+    // initial hidden states are h(l, -1) and c(l, -1)
+    // input x is copied to h(-1, s)
+    computation h({l, s, k, i}, p_float32);
+    computation c({l, s, k, i}, p_float32);
     computation h_init({l, k, i}, expr(float(0)));
     computation c_init({l, k, i}, expr(float(0)));
-    computation h_copy_x({m, k, i}, x(m, k, i));
-    computation sum_init({m, l, k, i_merged}, b(l, i_merged));
-    computation sum1({m, l},
+    computation h_copy_x({s, k, i}, x(s, k, i));
+    computation sum_init({l, s, k, i_merged}, b(l, i_merged));
+    // Multiplication from input is 2xbatched:
+    computation sum1({l, s},
         cublas_sgemm(buf_h, buf_Weights, buf_tmp,
                      BATCH_SIZE, 4 * FEATURE_SIZE, FEATURE_SIZE,
                      1, 1,  // alpha, beta
                      0, 0, 0,  // ldABC
-                     ((l + 1) * (SEQ_LENGTH + 1) + m) * BATCH_SIZE * FEATURE_SIZE,  //offsetA
+                     ((l + 1) * (SEQ_LENGTH + 1) + s) * BATCH_SIZE * FEATURE_SIZE,  //offsetA
                      (l * 2) * 4 * FEATURE_SIZE * FEATURE_SIZE,  //offsetB
-                     m * BATCH_SIZE * 4 * FEATURE_SIZE,  // offsetC
+                     s * BATCH_SIZE * 4 * FEATURE_SIZE,  // offsetC
                      false, true));
-    computation sum2({m, l},
+    computation sum2({l, s},
         cublas_sgemm(buf_h, buf_Weights, buf_tmp,
                      BATCH_SIZE, 4 * FEATURE_SIZE, FEATURE_SIZE,
                      1, 1,  // alpha, beta
                      0, 0, 0,  // ldABC
-                     (l * (SEQ_LENGTH + 1) + m + 1) * BATCH_SIZE * FEATURE_SIZE,  //offsetA
+                     (l * (SEQ_LENGTH + 1) + s + 1) * BATCH_SIZE * FEATURE_SIZE,  //offsetA
                      (l * 2 + 1) * 4 * FEATURE_SIZE * FEATURE_SIZE,  //offsetB
-                     m * BATCH_SIZE * 4 * FEATURE_SIZE,  // offsetC
+                     s * BATCH_SIZE * 4 * FEATURE_SIZE,  // offsetC
                      false, true));
     #define sigmoid(x) expr(float(1)) / (1 + expr(o_expo, -(x)))
-    computation sig_i({m, l, k, i}, sigmoid(sum_init(m, l, k, i)));
-    computation tnh_z({m, l, k, i}, expr(o_tanh, sum_init(m, l, k, i + FEATURE_SIZE)));
-    computation sig_o({m, l, k, i}, sigmoid(sum_init(m, l, k, i + 2 * FEATURE_SIZE)));
-    computation sig_f({m, l, k, i}, sigmoid(sum_init(m, l, k, i + 3 * FEATURE_SIZE)));
-    computation mul_iz({m, l, k, i}, sig_i(m, l, k, i) * tnh_z(m, l, k, i));
-    computation mul_fc({m, l, k, i}, sig_f(m, l, k, i) * c(m - 1, l, k, i));
-    c.set_expression(mul_iz(m, l, k, i) + mul_fc(m, l, k, i));
-    computation tnh_c({m, l, k, i}, expr(o_tanh, c(m, l, k, i)));
-    h.set_expression(tnh_c(m, l, k, i) * sig_o(m, l, k, i));
+    computation sig_i({l, s, k, i}, sigmoid(sum_init(l, s, k, i)));
+    computation tnh_z({l, s, k, i}, expr(o_tanh, sum_init(l, s, k, i + FEATURE_SIZE)));
+    computation sig_o({l, s, k, i}, sigmoid(sum_init(l, s, k, i + 2 * FEATURE_SIZE)));
+    computation sig_f({l, s, k, i}, sigmoid(sum_init(l, s, k, i + 3 * FEATURE_SIZE)));
+    computation mul_iz({l, s, k, i}, sig_i(l, s, k, i) * tnh_z(l, s, k, i));
+    computation mul_fc({l, s, k, i}, sig_f(l, s, k, i) * c(l, s - 1, k, i));
+    c.set_expression(mul_iz(l, s, k, i) + mul_fc(l, s, k, i));
+    computation tnh_c({l, s, k, i}, expr(o_tanh, c(l, s, k, i)));
+    h.set_expression(tnh_c(l, s, k, i) * sig_o(l, s, k, i));
     // Output is the last layer
-    computation y({m, k, i}, h(m, NUM_LAYERS - 1, k, i));
+    computation y({s, k, i}, h(NUM_LAYERS - 1, s, k, i));
     // Copies
     computation copy_Weights_to_device({}, memcpy(buf_Weights_cpu, buf_Weights));
     computation copy_biases_to_device({}, memcpy(buf_biases_cpu, buf_biases));
@@ -114,9 +115,9 @@ int main(int argc, char **argv)
             .then(c_init, computation::root)
             .then(h_copy_x, computation::root)
             .then(sum_init, computation::root)
-            .then(sum1, l)
-            .then(sum2, l)
-            .then(sig_i, i1)
+            .then(sum1, s)
+            .then(sum2, s)
+            .then(sig_i, s)
             .then(tnh_z, i1)
             .then(sig_o, i1)
             .then(sig_f, i1)
@@ -138,7 +139,7 @@ int main(int argc, char **argv)
     b.store_in(&buf_biases, {l, i_merged});
     x.store_in(&buf_x);
     y.store_in(&buf_y);
-    sum_init.store_in(&buf_tmp, {m, k, i_merged});
+    sum_init.store_in(&buf_tmp, {s, k, i_merged});
     sig_i.store_in(&buf_tmp_i, {k, i});
     tnh_z.store_in(&buf_tmp_z, {k, i});
     sig_o.store_in(&buf_tmp_o, {k, i});
@@ -146,11 +147,11 @@ int main(int argc, char **argv)
     mul_iz.store_in(&buf_tmp_i, {k, i});
     mul_fc.store_in(&buf_tmp_f, {k, i});
     tnh_c.store_in(&buf_tmp_i, {k, i});
-    h.store_in(&buf_h, {l + 1, m + 1, k, i});
-    c.store_in(&buf_c, {m + 1, l, k, i});
+    h.store_in(&buf_h, {l + 1, s + 1, k, i});
+    c.store_in(&buf_c, {l, s + 1, k, i});
     h_init.store_in(&buf_h, {l + 1, 0, k, i});
-    c_init.store_in(&buf_c, {0, l, k, i});
-    h_copy_x.store_in(&buf_h, {0, m + 1, k, i});
+    c_init.store_in(&buf_c, {l, 0, k, i});
+    h_copy_x.store_in(&buf_h, {0, s + 1, k, i});
 
     // -------------------------------------------------------
     // Code Generation

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
@@ -12,11 +12,28 @@ typedef std::chrono::duration<double,std::milli> duration_t;
 
 int main(int argc, char *argv[])
 {
+    int check_correctness = 0;
     int testN_tiramisu = 100;
     int testN_cudnn = 100;
     int warmupN = 10;
 
-    bool correctness_check = false;
+    if (argc > 1) {
+        testN_tiramisu = atoi(argv[1]);
+    }
+    if (argc > 2) {
+        testN_cudnn = atoi(argv[2]);
+    }
+    if (argc > 3) {
+        warmupN = atoi(argv[3]);
+    }
+    if (argc > 4) {
+        check_correctness = atoi(argv[4]);
+    }
+    if (check_correctness) {
+        testN_tiramisu = 0;
+        testN_cudnn = 0;
+        warmupN = 0;
+    }
 
     // Raw inputs
     float *raw_Weights = (float*) malloc(FEATURE_SIZE * 4 * FEATURE_SIZE * 2 * NUM_LAYERS * sizeof(float));
@@ -31,7 +48,7 @@ int main(int argc, char *argv[])
     Halide::Buffer<float> buf_y(FEATURE_SIZE, BATCH_SIZE, SEQ_LENGTH);
     Halide::Buffer<float> buf_ref_y(FEATURE_SIZE, BATCH_SIZE, SEQ_LENGTH);
 
-    if (correctness_check) {
+    if (check_correctness) {
         std::srand(0);
         for (int i = 0; i < NUM_LAYERS; i++)
             for (int j = 0; j < 2; j++)


### PR DESCRIPTION
Several optimizations for LSTM with cuBLAS benchmark including batched GEMM, loop interchange, and fusion. Correctness test passes with small margin of floating point arithmetic error. The latest numbers are:
`filter x batch x layer x sequence = 512 x 64 x 4 x 100`:
Tiramisu: 114.2ms (vs. previous PR: 162.2ms)
cuDNN: 54.3ms

The next big improvement will be to use streaming API to increase parallelism. There seems to be a simple way to get this via parallelizing kernel calls, but this doesn't work since loop tagging API we have is not compatible with cuda API (it's actually a more general problem). Let's discuss this when we meet.