### PR TITLE
Cuda_ast formatting fixes

### DIFF
--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/CMakeLists.txt
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/CMakeLists.txt
@@ -20,5 +20,6 @@ target_link_libraries(${wrapper_name} tiramisu ${HalideLib} ${ISLLib} ${LINK_FLA
 target_include_directories(${wrapper_name} PUBLIC ${cudnn_location}/include)
 
 add_custom_target(run_${benchmark_name} COMMAND ${wrapper_name})
-add_custom_target(run_${benchmark_name}_nvprof COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --profile-from-start off --print-gpu-trace $<TARGET_FILE:${wrapper_name}> 1 0 DEPENDS ${wrapper_name})
+add_custom_target(run_${benchmark_name}_correctness COMMAND ${wrapper_name} 0 0 0 1)
+add_custom_target(run_${benchmark_name}_nvprof COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --profile-from-start off --print-gpu-trace $<TARGET_FILE:${wrapper_name}> DEPENDS ${wrapper_name})
 add_custom_target(run_${benchmark_name}_nvprof2 COMMAND LD_LIBRARY_PATH=${CUDA_TOOLKIT_ROOT_DIR}/lib64 ${CUDA_TOOLKIT_ROOT_DIR}/bin/nvprof --profile-from-start off $<TARGET_FILE:${wrapper_name}> DEPENDS ${wrapper_name})

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/configuration.h
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/configuration.h
@@ -1,4 +1,4 @@
-#define FEATURE_SIZE int32_t(512)
-#define BATCH_SIZE int32_t(64)
-#define NUM_LAYERS int32_t(4)
-#define SEQ_LENGTH int32_t(10)  // 100
+#define FEATURE_SIZE int32_t(512)  // 512
+#define BATCH_SIZE int32_t(64)  // 64
+#define NUM_LAYERS int32_t(4)  // 4
+#define SEQ_LENGTH int32_t(100)  // 100

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/generator.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/generator.cpp
@@ -18,12 +18,12 @@ int main(int argc, char **argv)
     var i_merged("i_merged", 0, 4 * FEATURE_SIZE);
     var i0("i0"), i1("i1"), k0("k0"), k1("k1");
     // Outer dimensions
-    var l("l", 0, NUM_LAYERS), m("m", 0, SEQ_LENGTH);
+    var l("l", 0, NUM_LAYERS), s("s", 0, SEQ_LENGTH);
 
     input R("R", {l, i_merged, j}, p_float32);
     input W("W", {l, i_merged, j}, p_float32);
     input b("b", {l, i_merged}, p_float32);
-    input x({m, k, i}, p_float32);
+    input x({s, k, i}, p_float32);
 
     buffer buf_Weights_cpu("buf_Weights_cpu", {NUM_LAYERS, 2, 4 * FEATURE_SIZE, FEATURE_SIZE}, p_float32, a_input);
     buffer buf_Weights("buf_Weights", {NUM_LAYERS, 2, 4 * FEATURE_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
     buffer buf_tmp_z("buf_tmp_z", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_tmp_o("buf_tmp_o", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buffer buf_tmp_f("buf_tmp_f", {BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
-    buffer buf_c("buf_c", {SEQ_LENGTH + 1, NUM_LAYERS, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
+    buffer buf_c("buf_c", {NUM_LAYERS, SEQ_LENGTH + 1, BATCH_SIZE, FEATURE_SIZE}, p_float32, a_temporary);
     buf_Weights.tag_gpu_global();
     buf_h.tag_gpu_global();
     buf_tmp.tag_gpu_global();
@@ -52,46 +52,47 @@ int main(int argc, char **argv)
     buf_tmp_f.tag_gpu_global();
     buf_c.tag_gpu_global();
 
-    // h(m, l) is the output of the block (m, l)
-    // which takes h(m - 1, l) and h(m, l - 1) as inputs
-    // initial hidden states are h(-1, l) and c(-1, l)
-    // input x is copied to h(m, -1)
-    computation h({m, l, k, i}, p_float32);
-    computation c({m, l, k, i}, p_float32);
+    // h(l, s) is the output of the block (l, s)
+    // which takes h(l, s - 1) and h(l - 1, s) as inputs
+    // initial hidden states are h(l, -1) and c(l, -1)
+    // input x is copied to h(-1, s)
+    computation h({l, s, k, i}, p_float32);
+    computation c({l, s, k, i}, p_float32);
     computation h_init({l, k, i}, expr(float(0)));
     computation c_init({l, k, i}, expr(float(0)));
-    computation h_copy_x({m, k, i}, x(m, k, i));
-    computation sum_init({m, l, k, i_merged}, b(l, i_merged));
-    computation sum1({m, l},
+    computation h_copy_x({s, k, i}, x(s, k, i));
+    computation sum_init({l, s, k, i_merged}, b(l, i_merged));
+    // Multiplication from input is 2xbatched:
+    computation sum1({l, s},
         cublas_sgemm(buf_h, buf_Weights, buf_tmp,
                      BATCH_SIZE, 4 * FEATURE_SIZE, FEATURE_SIZE,
                      1, 1,  // alpha, beta
                      0, 0, 0,  // ldABC
-                     ((l + 1) * (SEQ_LENGTH + 1) + m) * BATCH_SIZE * FEATURE_SIZE,  //offsetA
+                     ((l + 1) * (SEQ_LENGTH + 1) + s) * BATCH_SIZE * FEATURE_SIZE,  //offsetA
                      (l * 2) * 4 * FEATURE_SIZE * FEATURE_SIZE,  //offsetB
-                     m * BATCH_SIZE * 4 * FEATURE_SIZE,  // offsetC
+                     s * BATCH_SIZE * 4 * FEATURE_SIZE,  // offsetC
                      false, true));
-    computation sum2({m, l},
+    computation sum2({l, s},
         cublas_sgemm(buf_h, buf_Weights, buf_tmp,
                      BATCH_SIZE, 4 * FEATURE_SIZE, FEATURE_SIZE,
                      1, 1,  // alpha, beta
                      0, 0, 0,  // ldABC
-                     (l * (SEQ_LENGTH + 1) + m + 1) * BATCH_SIZE * FEATURE_SIZE,  //offsetA
+                     (l * (SEQ_LENGTH + 1) + s + 1) * BATCH_SIZE * FEATURE_SIZE,  //offsetA
                      (l * 2 + 1) * 4 * FEATURE_SIZE * FEATURE_SIZE,  //offsetB
-                     m * BATCH_SIZE * 4 * FEATURE_SIZE,  // offsetC
+                     s * BATCH_SIZE * 4 * FEATURE_SIZE,  // offsetC
                      false, true));
     #define sigmoid(x) expr(float(1)) / (1 + expr(o_expo, -(x)))
-    computation sig_i({m, l, k, i}, sigmoid(sum_init(m, l, k, i)));
-    computation tnh_z({m, l, k, i}, expr(o_tanh, sum_init(m, l, k, i + FEATURE_SIZE)));
-    computation sig_o({m, l, k, i}, sigmoid(sum_init(m, l, k, i + 2 * FEATURE_SIZE)));
-    computation sig_f({m, l, k, i}, sigmoid(sum_init(m, l, k, i + 3 * FEATURE_SIZE)));
-    computation mul_iz({m, l, k, i}, sig_i(m, l, k, i) * tnh_z(m, l, k, i));
-    computation mul_fc({m, l, k, i}, sig_f(m, l, k, i) * c(m - 1, l, k, i));
-    c.set_expression(mul_iz(m, l, k, i) + mul_fc(m, l, k, i));
-    computation tnh_c({m, l, k, i}, expr(o_tanh, c(m, l, k, i)));
-    h.set_expression(tnh_c(m, l, k, i) * sig_o(m, l, k, i));
+    computation sig_i({l, s, k, i}, sigmoid(sum_init(l, s, k, i)));
+    computation tnh_z({l, s, k, i}, expr(o_tanh, sum_init(l, s, k, i + FEATURE_SIZE)));
+    computation sig_o({l, s, k, i}, sigmoid(sum_init(l, s, k, i + 2 * FEATURE_SIZE)));
+    computation sig_f({l, s, k, i}, sigmoid(sum_init(l, s, k, i + 3 * FEATURE_SIZE)));
+    computation mul_iz({l, s, k, i}, sig_i(l, s, k, i) * tnh_z(l, s, k, i));
+    computation mul_fc({l, s, k, i}, sig_f(l, s, k, i) * c(l, s - 1, k, i));
+    c.set_expression(mul_iz(l, s, k, i) + mul_fc(l, s, k, i));
+    computation tnh_c({l, s, k, i}, expr(o_tanh, c(l, s, k, i)));
+    h.set_expression(tnh_c(l, s, k, i) * sig_o(l, s, k, i));
     // Output is the last layer
-    computation y({m, k, i}, h(m, NUM_LAYERS - 1, k, i));
+    computation y({s, k, i}, h(NUM_LAYERS - 1, s, k, i));
     // Copies
     computation copy_Weights_to_device({}, memcpy(buf_Weights_cpu, buf_Weights));
     computation copy_biases_to_device({}, memcpy(buf_biases_cpu, buf_biases));
@@ -114,9 +115,9 @@ int main(int argc, char **argv)
             .then(c_init, computation::root)
             .then(h_copy_x, computation::root)
             .then(sum_init, computation::root)
-            .then(sum1, l)
-            .then(sum2, l)
-            .then(sig_i, i1)
+            .then(sum1, s)
+            .then(sum2, s)
+            .then(sig_i, s)
             .then(tnh_z, i1)
             .then(sig_o, i1)
             .then(sig_f, i1)
@@ -138,7 +139,7 @@ int main(int argc, char **argv)
     b.store_in(&buf_biases, {l, i_merged});
     x.store_in(&buf_x);
     y.store_in(&buf_y);
-    sum_init.store_in(&buf_tmp, {m, k, i_merged});
+    sum_init.store_in(&buf_tmp, {s, k, i_merged});
     sig_i.store_in(&buf_tmp_i, {k, i});
     tnh_z.store_in(&buf_tmp_z, {k, i});
     sig_o.store_in(&buf_tmp_o, {k, i});
@@ -146,11 +147,11 @@ int main(int argc, char **argv)
     mul_iz.store_in(&buf_tmp_i, {k, i});
     mul_fc.store_in(&buf_tmp_f, {k, i});
     tnh_c.store_in(&buf_tmp_i, {k, i});
-    h.store_in(&buf_h, {l + 1, m + 1, k, i});
-    c.store_in(&buf_c, {m + 1, l, k, i});
+    h.store_in(&buf_h, {l + 1, s + 1, k, i});
+    c.store_in(&buf_c, {l, s + 1, k, i});
     h_init.store_in(&buf_h, {l + 1, 0, k, i});
-    c_init.store_in(&buf_c, {0, l, k, i});
-    h_copy_x.store_in(&buf_h, {0, m + 1, k, i});
+    c_init.store_in(&buf_c, {l, 0, k, i});
+    h_copy_x.store_in(&buf_h, {0, s + 1, k, i});
 
     // -------------------------------------------------------
     // Code Generation

--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.cpp
@@ -12,11 +12,28 @@ typedef std::chrono::duration<double,std::milli> duration_t;
 
 int main(int argc, char *argv[])
 {
+    int check_correctness = 0;
     int testN_tiramisu = 100;
     int testN_cudnn = 100;
     int warmupN = 10;
 
-    bool correctness_check = false;
+    if (argc > 1) {
+        testN_tiramisu = atoi(argv[1]);
+    }
+    if (argc > 2) {
+        testN_cudnn = atoi(argv[2]);
+    }
+    if (argc > 3) {
+        warmupN = atoi(argv[3]);
+    }
+    if (argc > 4) {
+        check_correctness = atoi(argv[4]);
+    }
+    if (check_correctness) {
+        testN_tiramisu = 0;
+        testN_cudnn = 0;
+        warmupN = 0;
+    }
 
     // Raw inputs
     float *raw_Weights = (float*) malloc(FEATURE_SIZE * 4 * FEATURE_SIZE * 2 * NUM_LAYERS * sizeof(float));
@@ -31,7 +48,7 @@ int main(int argc, char *argv[])
     Halide::Buffer<float> buf_y(FEATURE_SIZE, BATCH_SIZE, SEQ_LENGTH);
     Halide::Buffer<float> buf_ref_y(FEATURE_SIZE, BATCH_SIZE, SEQ_LENGTH);
 
-    if (correctness_check) {
+    if (check_correctness) {
         std::srand(0);
         for (int i = 0; i < NUM_LAYERS; i++)
             for (int j = 0; j < 2; j++)

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -166,26 +166,26 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
     }
 }
 
-    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_if(isl_ast_node *node) {
-        isl_ast_node *then_body = isl_ast_node_if_get_then(node);
-        isl_ast_expr_ptr condition{isl_ast_node_if_get_cond(node)};
+cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_if(isl_ast_node *node) {
+    isl_ast_node *then_body = isl_ast_node_if_get_then(node);
+    isl_ast_expr_ptr condition{isl_ast_node_if_get_cond(node)};
 
-        statement_ptr then_body_stmt{cuda_stmt_from_isl_node(then_body)};
-        statement_ptr else_body_stmt;
-        if (isl_ast_node_if_has_else(node)) {
-            isl_ast_node *else_body = isl_ast_node_if_get_else(node);
-            else_body_stmt = cuda_stmt_from_isl_node(else_body);
-        }
-
-        statement_ptr condition_stmt{cuda_stmt_handle_isl_expr(condition, node)};
-
-        if (else_body_stmt) {
-            return statement_ptr{new cuda_ast::if_condition{condition_stmt, then_body_stmt, else_body_stmt}};
-        } else {
-            return statement_ptr{new cuda_ast::if_condition{condition_stmt, then_body_stmt}};
-        }
-
+    statement_ptr then_body_stmt{cuda_stmt_from_isl_node(then_body)};
+    statement_ptr else_body_stmt;
+    if (isl_ast_node_if_has_else(node)) {
+        isl_ast_node *else_body = isl_ast_node_if_get_else(node);
+        else_body_stmt = cuda_stmt_from_isl_node(else_body);
     }
+
+    statement_ptr condition_stmt{cuda_stmt_handle_isl_expr(condition, node)};
+
+    if (else_body_stmt) {
+        return statement_ptr{new cuda_ast::if_condition{condition_stmt, then_body_stmt, else_body_stmt}};
+    } else {
+        return statement_ptr{new cuda_ast::if_condition{condition_stmt, then_body_stmt}};
+    }
+
+}
 
     cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_block(isl_ast_node *node) {
         isl_ast_node_list_ptr children_list{isl_ast_node_block_get_children(node)};
@@ -208,8 +208,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         }
     }
 
-    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_val_from_for_condition(isl_ast_expr_ptr &expr, isl_ast_node *node)
-    {
+    cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_val_from_for_condition(isl_ast_expr_ptr &expr, isl_ast_node *node) {
         // TODO this is potentially a hack
         assert(isl_ast_expr_get_type(expr.get()) == isl_ast_expr_type::isl_ast_expr_op);
         auto expr_type = isl_ast_expr_get_op_type(expr.get());
@@ -261,12 +260,10 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
         // Check if GPU
         auto gpu_it = gpu_iterators.find(iterator_name);
-        if (gpu_it != gpu_iterators.end())
-        {
+        if (gpu_it != gpu_iterators.end()) {
             current_kernel->set_dimension(gpu_it->second);
             gpu_iterators.erase(gpu_it);
-            if (gpu_iterators.empty())
-            {
+            if (gpu_iterators.empty()) {
                 auto * final_body = new cuda_ast::block;
                 for (auto &dec : kernel_simplified_vars)
                     final_body->add_statement(dec);
@@ -293,9 +290,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
             } else {
                 result = body_statement;
             }
-        }
-        else
-        {
+        } else {
             auto it = std::static_pointer_cast<cuda_ast::scalar>(cuda_stmt_handle_isl_expr(iterator, node));
             auto initializer_statement = statement_ptr{new declaration{
                     assignment_ptr{new scalar_assignment{it, initializer_stmt}}}};
@@ -345,7 +340,6 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         }
     }
 
-
     cuda_ast::value_ptr cuda_ast::generator::cuda_stmt_handle_isl_val(isl_val_ptr &node) {
         // TODO handle infinity
         long num = isl_val_get_num_si(node.get());
@@ -353,7 +347,6 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         assert(den == 1);
         return value_ptr{new cuda_ast::value{value_cast(global::get_loop_iterator_data_type(), num)}};
     }
-
 
     cuda_ast::statement_ptr cuda_ast::generator::parse_tiramisu(const tiramisu::expr &tiramisu_expr) {
         switch (tiramisu_expr.get_expr_type()) {
@@ -398,8 +391,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
                             return parse_tiramisu(tiramisu_expr.get_operand(0));
                         }
                     }
-                    case o_allocate:
-                    {
+                    case o_allocate: {
                         auto buffer = get_buffer(tiramisu_expr.get_name());
                         if (buffer->get_location() == memory_location::shared
                                 || buffer->get_location() == memory_location::local
@@ -458,9 +450,9 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
     cuda_ast::buffer_ptr cuda_ast::generator::get_buffer(const std::string &name) {
         auto it = m_buffers.find(name);
         cuda_ast::buffer_ptr buffer;
-        if (it != m_buffers.end())
+        if (it != m_buffers.end()) {
             buffer = it->second;
-        else {
+        } else {
             auto tiramisu_buffer = this->m_fct.get_buffers().at(name);
             std::vector<cuda_ast::statement_ptr> sizes;
             for (auto &dim : tiramisu_buffer->get_dim_sizes()) {
@@ -471,8 +463,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
                                                      tiramisu_buffer->location, sizes}};
             m_buffers[name] = buffer;
         }
-        if (in_kernel && gpu_local.find(name) == gpu_local.end())
-        {
+        if (in_kernel && gpu_local.find(name) == gpu_local.end()) {
             current_kernel->add_used_buffer(buffer);
         }
         return buffer;
@@ -483,8 +474,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
                                                                       cuda_ast::statement_ptr upper_bound) {
         auto min_cap = upper_bound->extract_min_cap();
         statement_ptr actual_bound;
-        if (min_cap.first)
-        {
+        if (min_cap.first) {
             actual_bound = min_cap.first;
         } else {
             actual_bound = upper_bound;
@@ -592,13 +582,9 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
             }
             if (comp->get_expr().get_expr_type() == e_sync) {
                 return statement_ptr{new cuda_ast::sync};
-            }
-            else if (comp->get_expr().get_op_type() == o_memcpy)
-            {
+            } else if (comp->get_expr().get_op_type() == o_memcpy) {
                 return statement_ptr{parse_tiramisu(comp->get_expr())};
-            }
-            else if (comp->get_expr().get_op_type() == o_allocate)
-            {
+            } else if (comp->get_expr().get_op_type() == o_allocate) {
                 this->gpu_local.insert(comp->get_expr().get_name());
                 auto buffer = get_buffer(comp->get_expr().get_name());
                 if (buffer->get_location() == memory_location::shared
@@ -619,25 +605,21 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
                 return statement_ptr{new cuda_ast::function_call{e.get_data_type(), e.get_name(), arguments}};
             } else {
                 auto &associated_lets = comp->get_associated_let_stmts();
-                for (auto &statement: associated_lets)
-                {
+                for (auto &statement: associated_lets) {
                     this->m_scalar_data.insert(std::make_pair(statement.first, std::make_pair(statement.second.get_data_type(), memory_location::reg)));
                 }
                 if (index_exprs.find(comp) == index_exprs.end())
                     index_exprs[comp] = comp->index_expr;
                 auto result = comp->create_tiramisu_assignment(index_exprs[comp]);
                 statement_ptr asgmnt;
-                if (result.first.get_expr_type() == e_var)
-                {
+                if (result.first.get_expr_type() == e_var) {
                     cuda_ast::scalar_ptr s = scalar_ptr{new scalar{result.first.get_data_type(), result.first.get_name(), memory_location::reg, true}};
                     // TODO associated let statement doesn't work well with declaration
                     asgmnt = statement_ptr{new declaration{assignment_ptr{new scalar_assignment{s, parse_tiramisu(result.second)}}}};
                     // TODO remove once done
                     m_scalar_data.insert(std::make_pair(result.first.get_name(), std::make_pair(result.first.get_data_type(), memory_location::reg)));
                     gpu_local.insert(result.first.get_name());
-                }
-                else
-                {
+                } else {
                     cuda_ast::buffer_ptr b = this->get_buffer(result.first.get_name());
                     asgmnt = statement_ptr{new buffer_assignment{b, parse_tiramisu(result.first.get_access()[0]),
                                                                   parse_tiramisu(result.second)}};
@@ -720,8 +702,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         auto *body = new cuda_ast::block;
         auto main_body = generator.cuda_stmt_from_isl_node(this->get_isl_ast());
 
-        for (auto &kernel : generator.kernels)
-        {
+        for (auto &kernel : generator.kernels) {
             body->add_statement(cuda_ast::statement_ptr{new cuda_ast::kernel_definition{kernel}});
         }
         auto function_body = new cuda_ast::block;
@@ -755,8 +736,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
                 buf->mark_as_allocated();
 
-                if (buf->location == cuda_ast::memory_location::constant)
-                {
+                if (buf->location == cuda_ast::memory_location::constant) {
                     const_buffer_declaration.push_back(declaration);
                     auto hf = new cuda_ast::host_function{p_none, buf->get_name() + "_get_symbol", {},
                                             cuda_ast::statement_ptr{new cuda_ast::return_statement{std::static_pointer_cast<cuda_ast::statement>(cuda_ast_buffer)}}};
@@ -784,8 +764,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
             resulting_file->add_statement(s);
 
 
-        for (auto &kernel: generator.kernels)
-        {
+        for (auto &kernel: generator.kernels) {
             resulting_file->add_statement(cuda_ast::statement_ptr{new cuda_ast::kernel_definition{kernel}});
 
             std::shared_ptr<cuda_ast::block> wrapper_block{new cuda_ast::block};
@@ -821,7 +800,6 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
                                                                cuda_ast::memory_location::reg)));
         }
     }
-
 
     cuda_ast::statement::statement(primitive_t type) : type(type) {}
 
@@ -982,15 +960,13 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         }
     }
 
-
     void cuda_ast::scalar::print(std::stringstream &ss, const std::string &base) {std::string name;
         statement_ptr body;
         ss << get_name();
     }
 
     void cuda_ast::value::print(std::stringstream &ss, const std::string &base) {
-        switch (get_type())
-        {
+        switch (get_type()) {
             case p_uint8:
             ss << +u8_val;
                 break;
@@ -1149,8 +1125,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
     void cuda_ast::buffer::print_declaration(std::stringstream &ss, const std::string &base) {
         ss << tiramisu_type_to_cuda_type(get_type()) << " ";
-        if (this->get_location() == memory_location::global || this->get_location() == memory_location::host)
-        {
+        if (this->get_location() == memory_location::global || this->get_location() == memory_location::host) {
             ss << "*" << get_name();
         } else if (this->get_location() == memory_location::reg) {
             ss << get_name();
@@ -1191,8 +1166,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
 
     void cuda_ast::kernel::dim3d_t::set(gpu_iterator::dimension_t dim, statement_ptr size) {
-        switch (dim)
-        {
+        switch (dim) {
             case gpu_iterator::dimension_t::x:
                 this->x.swap(size);
                 break;
@@ -1251,11 +1225,9 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
             arguments.push_back(c.second);
         for (auto &b: kernel->used_buffers)
             arguments.push_back(b.second);
-        for (auto it = arguments.begin(); it != arguments.end();)
-        {
+        for (auto it = arguments.begin(); it != arguments.end();) {
             (*it)->print(ss, base);
-            if (++it != arguments.end())
-            {
+            if (++it != arguments.end()) {
                 ss << ", ";
             }
         }
@@ -1280,11 +1252,9 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
     void cuda_ast::kernel_definition::print(std::stringstream &ss, const std::string &base) {
         ss << "static __global__ void " << kernel->get_name() << "(";
         auto arguments = kernel->get_arguments();
-        for (auto it = arguments.begin(); it != arguments.end();)
-        {
+        for (auto it = arguments.begin(); it != arguments.end();) {
             (*it)->print_declaration(ss, base);
-            if (++it != arguments.end())
-            {
+            if (++it != arguments.end()) {
                 ss << ", ";
             }
         }
@@ -1297,11 +1267,9 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
     cuda_ast::gpu_iterator_read::gpu_iterator_read(gpu_iterator it, bool simplified) : statement(global::get_loop_iterator_data_type()), it(it), simplified(simplified){}
 
     void cuda_ast::gpu_iterator_read::print(std::stringstream &ss, const std::string &base) {
-        if (simplified)
-        {
+        if (simplified) {
             ss << it.simplified_name();
-        }
-        else {
+        } else {
             switch (it.type) {
                 case gpu_iterator::type_t::BLOCK:
                     ss << "blockIdx";
@@ -1345,11 +1313,9 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         if (pointer_return)
             ss << "*";
         ss << " " << name << "(";
-        for (int i = 0; i < arguments.size();)
-        {
+        for (int i = 0; i < arguments.size();) {
             arguments[i]->print_declaration(ss, base);
-            if (++i < arguments.size())
-            {
+            if (++i < arguments.size()) {
                 ss << ", ";
             }
         }
@@ -1358,8 +1324,8 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
     }
 
     cuda_ast::memcpy::memcpy(buffer_ptr from, buffer_ptr to) : statement(p_none), from(from), to(to) {}
-    void cuda_ast::memcpy::print(std::stringstream &ss, const std::string &base)
-    {
+
+    void cuda_ast::memcpy::print(std::stringstream &ss, const std::string &base) {
         ss << "cudaMemcpy(" << to->get_name() << ", ";
         ss << from->get_name() << ", ";
         to->print_size(ss, base, " * ");
@@ -1375,8 +1341,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
     cuda_ast::free::free(buffer_ptr b) : statement(p_none), b(b){}
 
     void cuda_ast::allocate::print(std::stringstream &ss, const std::string &base) {
-        switch(b->get_location())
-        {
+        switch(b->get_location()) {
             case memory_location::host:
                 ss << b->get_name() << " = (" << tiramisu_type_to_cuda_type(b->get_type()) << "*)malloc(";
                 break;
@@ -1390,8 +1355,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         ss << " * sizeof(" << tiramisu_type_to_cuda_type(b->get_type()) << "))";
     }
     void cuda_ast::free::print(std::stringstream &ss, const std::string &base) {
-        switch(b->get_location())
-        {
+        switch(b->get_location()) {
             case memory_location::host:
                 ss << "free";
                 break;
@@ -1447,8 +1411,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
     std::unordered_set<std::string> cuda_ast::function_call::extract_scalars() {
         std::unordered_set<std::string> result;
-        for (auto &arg: arguments)
-        {
+        for (auto &arg: arguments) {
             auto subresult = arg->extract_scalars();
             result.insert(subresult.begin(), subresult.end());
         }
@@ -1475,8 +1438,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
     std::unordered_set<std::string> cuda_ast::op::extract_scalars() {
         std::unordered_set<std::string> result;
-        for (auto &op: m_operands)
-        {
+        for (auto &op: m_operands) {
             auto subresult = op->extract_scalars();
             result.insert(subresult.begin(), subresult.end());
         }
@@ -1494,8 +1456,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
     }
 
     cuda_ast::value_ptr cuda_ast::value::copy() {
-        switch (get_type())
-        {
+        switch (get_type()) {
             case p_uint8:
                 return value_ptr{new value{u8_val}};
                 break;
@@ -1545,8 +1506,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
     std::unordered_set<std::string> cuda_ast::buffer_access::extract_scalars() {
         std::unordered_set<std::string> result;
-        for (auto &index: this->access)
-        {
+        for (auto &index: this->access) {
             auto subresult = index->extract_scalars();
             result.insert(subresult.begin(), subresult.end());
         }
@@ -1554,11 +1514,9 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
     }
 
-
     std::string cuda_ast::gpu_iterator::simplified_name() {
         std::string result = "__";
-        switch (type)
-        {
+        switch (type) {
             case type_t::THREAD :
                 result += "t";
                 break;
@@ -1566,8 +1524,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
                 result += "b";
                 break;
         }
-        switch (dimension)
-        {
+        switch (dimension) {
             case dimension_t::x :
                 result += "x";
                 break;
@@ -1599,21 +1556,16 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
             auto data_it = m_scalar_data.find(name);
             auto const &data = data_it->second;
             scalar_ptr used_scalar{new cuda_ast::scalar{data.first, name, data.second}};
-            if (this->in_kernel)
-            {
+            if (this->in_kernel) {
                 // Check if it was defined inside
                 bool defined_inside = gpu_local.find(name) != gpu_local.end();
-                if (!defined_inside)
-                {
-                    for (auto it = iterator_stack.rbegin(); it != iterator_stack.rend(); it++)
-                    {
-                        if (name == *it)
-                        {
+                if (!defined_inside) {
+                    for (auto it = iterator_stack.rbegin(); it != iterator_stack.rend(); it++) {
+                        if (name == *it) {
                             defined_inside = true;
                             break;
                         }
-                        if (gpu_iterators.find(name) != gpu_iterators.end())
-                        {
+                        if (gpu_iterators.find(name) != gpu_iterators.end()) {
                             break;
                         }
                     }
@@ -1628,8 +1580,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
     }
 
     cuda_ast::value::value(const tiramisu::expr &expr) : statement(expr.get_data_type()) {
-        switch (get_type())
-        {
+        switch (get_type()) {
             case p_uint8:
                 u8_val = expr.get_uint8_value();
                 break;
@@ -1692,8 +1643,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         FILE * file{popen(cmd.c_str(), "r")};
         if (!file)
             return exec_result{false, -1, "", ""};
-        while (!feof(file))
-        {
+        while (!feof(file)) {
             if (fgets(buffer.data(), 128, file) != nullptr)
                 out << buffer.data();
         }
@@ -1723,8 +1673,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
         auto result = exec(command.str());
 
-        if (result.fail())
-        {
+        if (result.fail()) {
             ERROR("Failed to compile the CPU object for the GPU code.", false);
         }
 
@@ -1733,8 +1682,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         return result.succeed();
     }
 
-    bool cuda_ast::compiler::compile_gpu_obj(const std::string &obj_name) const
-    {
+    bool cuda_ast::compiler::compile_gpu_obj(const std::string &obj_name) const {
         using namespace std;
         DEBUG_FCT_NAME(3);
         DEBUG_INDENT(4);
@@ -1752,8 +1700,7 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
 
         auto result = exec(command.str());
 
-        if (result.fail())
-        {
+        if (result.fail()) {
             ERROR("Failed to compile the GPU object for the GPU code.", false);
         }
 
@@ -1792,24 +1739,24 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_from_isl_node(isl_ast_nod
         return compile_cpu_obj(filename, obj_name) && compile_gpu_obj(obj_name);
     }
 
-    bool cuda_ast::abstract_identifier::is_buffer() const {
-        return false;
-    }
+bool cuda_ast::abstract_identifier::is_buffer() const {
+    return false;
+}
 
-    bool cuda_ast::buffer::is_buffer() const {
-        return true;
-    }
+bool cuda_ast::buffer::is_buffer() const {
+    return true;
+}
 
-    cuda_ast::return_statement::return_statement(statement_ptr return_value) : statement(p_none), return_value(return_value){}
+cuda_ast::return_statement::return_statement(statement_ptr return_value) : statement(p_none), return_value(return_value){}
 
-    void cuda_ast::return_statement::print(std::stringstream &ss, const std::string &base) {
-        ss << "return ";
-        return_value->print(ss, base);
-    }
+void cuda_ast::return_statement::print(std::stringstream &ss, const std::string &base) {
+    ss << "return ";
+    return_value->print(ss, base);
+}
 
-    void cuda_ast::host_function::set_pointer_return(bool val) {
-        pointer_return = val;
-    }
+void cuda_ast::host_function::set_pointer_return(bool val) {
+    pointer_return = val;
+}
 
 }  // namespace tiramisu
 


### PR DESCRIPTION
Please review https://github.com/Tiramisu-Compiler/tiramisu/pull/204 first.

Some formatting fixes for `tiramisu_codegen_cuda.cpp` to make it more coherent and understandable. No functionality changed, only curly braces and whitespace. Again, there's a lot more to fix but I don't want to edit the whole file to not to mess up with the git-blame history.