### PR TITLE
LSTM_cublas Benchmark Progress

### DIFF
--- a/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.h
+++ b/benchmarks/DNN/blocks/LSTM/gpu_lib/wrapper.h
@@ -6,7 +6,9 @@ extern "C" {
 int lstm(halide_buffer_t *b1,
          halide_buffer_t *b2,
          halide_buffer_t *b3,
-         halide_buffer_t *b4);
+         halide_buffer_t *b4,
+         halide_buffer_t *b5,
+         halide_buffer_t *b6);
 
 int lstm_ref(halide_buffer_t *b1,
          halide_buffer_t *b2,

--- a/include/tiramisu/core.h
+++ b/include/tiramisu/core.h
@@ -4661,6 +4661,13 @@ protected:
                                                      int coeff,
                                                      const tiramisu::function *fct);
 
+    /**
+     * Extract tags from the ISL ast node at given level. This is a helper
+     * function meant to be used from halide_stmt_from_isl_node. Traverses
+     * the ISL ast tree and fills the tagged_stmts vector.
+     */
+    static void extract_tags_from_isl_node(const tiramisu::function &fct, isl_ast_node *node, int level,
+                                           std::vector<std::pair<std::string, std::string>> &tagged_stmts);
 
     /**
       * Generate a Halide statement from an ISL ast node object in the ISL ast

--- a/include/tiramisu/expr.h
+++ b/include/tiramisu/expr.h
@@ -1996,7 +1996,9 @@ expr cublas_sgemm(const buffer &A, const buffer &B, buffer &C,
                   expr transposeA = false, expr transposeB = false);
 
 /**
- * TODO: Documentation
+ * Synchronize CUDA streams of current thread. This should be used whenever CUDA
+ * kernels are run in parallel to make sure all kernel calls are done before
+ * destroying the thread.
  */
 expr cuda_stream_synchronize();
 

--- a/include/tiramisu/expr.h
+++ b/include/tiramisu/expr.h
@@ -311,8 +311,10 @@ public:
         {
             tiramisu::str_dump("Binary operation between two expressions of different types:\n");
             expr0.dump(false);
+            tiramisu::str_dump(" (" + str_from_tiramisu_type_primitive(expr0.get_data_type()) + ")");
             tiramisu::str_dump(" and ");
             expr1.dump(false);
+            tiramisu::str_dump(" (" + str_from_tiramisu_type_primitive(expr1.get_data_type()) + ")");
             tiramisu::str_dump("\n");
             ERROR("\nThe two expressions should be of the same type. Use casting to elevate the type of one expression to the other.\n", true);
         }
@@ -1993,5 +1995,11 @@ expr cublas_sgemm(const buffer &A, const buffer &B, buffer &C,
                   expr offsetA = 0, expr offsetB = 0, expr offsetC = 0,
                   expr transposeA = false, expr transposeB = false);
 
+/**
+ * TODO: Documentation
+ */
+expr cuda_stream_synchronize();
+
 }
+
 #endif

--- a/include/tiramisu/type.h
+++ b/include/tiramisu/type.h
@@ -39,6 +39,7 @@ enum primitive_t
     p_boolean,
     p_async,
     p_wait_ptr,
+    p_void_ptr,  // Used for raw buffers in cuda_ast
     p_none
 };
 

--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -1658,6 +1658,8 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_if(isl_ast_nod
 
         stringstream command;
         command << NVCC_PATH;
+        // Basic streaming for parallelization
+        command << " --default-stream per-thread";
         // Say that this is actually cuda code
         command << " -x cu";
         // Create a .o file
@@ -1689,6 +1691,8 @@ cuda_ast::statement_ptr cuda_ast::generator::cuda_stmt_handle_isl_if(isl_ast_nod
 
         stringstream command;
         command << NVCC_PATH;
+        // Basic streaming for parallelization
+        command << " --default-stream per-thread";
         // Link device object code
         command << " -dlink";
         // Specify input file name

--- a/src/tiramisu_core.cpp
+++ b/src/tiramisu_core.cpp
@@ -5523,6 +5523,8 @@ std::string str_from_tiramisu_type_primitive(tiramisu::primitive_t type)
         return "bool";
     case tiramisu::p_wait_ptr:
         return "wait";
+    case tiramisu::p_void_ptr:
+        return "void *";
     default:
         ERROR("Tiramisu type not supported.", true);
         return "";
@@ -5692,6 +5694,9 @@ Halide::Type halide_type_from_tiramisu_type(tiramisu::primitive_t type)
         break;
     case tiramisu::p_wait_ptr:
         t = Halide::Handle();
+        break;
+    case tiramisu::p_void_ptr:
+        t = Halide::type_of<void *>();
         break;
     default:
         ERROR("Tiramisu type cannot be translated to Halide type.", true);
@@ -5947,7 +5952,7 @@ computation::computation(std::string name, std::vector<tiramisu::var> iterator_v
     is_let = false;
 
     // Allocate implicit buffer if possible
-    if (t != p_none && t != p_async && t != p_wait_ptr) {
+    if (t != p_none && t != p_async && t != p_wait_ptr && t != p_void_ptr) {
         bool is_bounded = true;
         std::vector<expr> buffer_size;
         for (const auto &var : iterator_variables) {

--- a/src/tiramisu_cuda_wrappers.cpp
+++ b/src/tiramisu_cuda_wrappers.cpp
@@ -101,6 +101,7 @@ int tiramisu_cublas_sgemm(float *A, float *B, float *C,
     // transposes the output again: cublas(A, B) = ((A^T)x(B^T))^T = BxA
     // So it is actually equivalent to row-major GEMM with inputs swapped.
     // We need to reorder the size parameters as well to make it work:
+    cublasSetStream(handle, cudaStreamPerThread);
     handle_cublas_error(
         cublasSgemm(handle,
                     transposeB ? CUBLAS_OP_T : CUBLAS_OP_N,
@@ -111,3 +112,11 @@ int tiramisu_cublas_sgemm(float *A, float *B, float *C,
          __FUNCTION__);
     return 0;
 }
+
+extern "C"
+int32_t tiramisu_cuda_stream_synchronize(int32_t dummy)
+{
+    cudaStreamSynchronize(0);
+    return 0;
+}
+

--- a/src/tiramisu_expr.cpp
+++ b/src/tiramisu_expr.cpp
@@ -177,7 +177,7 @@ expr tiramisu::expr::operator<<(tiramisu::expr other) const {
 }
 
 expr memcpy(const buffer &from, const buffer &to) {
-    return expr(o_memcpy, var(from.get_name()), var(to.get_name()));
+    return expr(o_memcpy, var(p_void_ptr, from.get_name()), var(p_void_ptr, to.get_name()));
 }
 
 expr allocate(const buffer &b)
@@ -204,9 +204,9 @@ expr cublas_sgemm(const buffer &A, const buffer &B, buffer &C,
     }
     return expr(o_call, "tiramisu_cublas_sgemm",
             {
-                var(A.get_name()),
-                var(B.get_name()),
-                var(C.get_name()),
+                var(p_void_ptr, A.get_name()),
+                var(p_void_ptr, B.get_name()),
+                var(p_void_ptr, C.get_name()),
                 cast(p_uint64, M), cast(p_uint64, N), cast(p_uint64, K),
                 cast(p_float32, alpha), cast(p_float32, beta),
                 cast(p_uint64, ldA), cast(p_uint64, ldB), cast(p_uint64, ldC),
@@ -214,6 +214,11 @@ expr cublas_sgemm(const buffer &A, const buffer &B, buffer &C,
                 cast(p_boolean, transposeA), cast(p_boolean, transposeB)
             },
             tiramisu::p_uint8);
+}
+
+expr cuda_stream_synchronize()
+{
+    return expr(o_call, "tiramisu_cuda_stream_synchronize", {int32_t(0)}, tiramisu::p_int32);
 }
 
 }


### PR DESCRIPTION
Please review https://github.com/Tiramisu-Compiler/tiramisu/pull/208 first.

Adding several optimizations to LSTM-with-cuBLAS benchmark.
- Parallelize LSTM blocks with the new streams API
- Pretranspose weights
- Fuse some kernels

While analyzing the profiler data I realized that Tiramisu time includes the `cuda_malloc` and `cuda_free` times as well, which is quite significant (~30%). To eliminate this comparison difference with cuDNN, runtime is now calculated from within the Tiramisu function using an helper function. Now we are only measuring the GPU time - excluding malloc, memcpy, and etc. Results are pretty close to cuDNN:

GPU time of `filter x batch x layer x sequence = 512 x 64 x 4 x 100` on Salike(K80):
Tiramisu: 57.6ms
cuDNN: 50.4ms

Now we have all the optimizations mentioned in the Nvidia blog post. Also I'm using a bigger GEMM batch than the one mentioned in the blog post which gives better performance. There might still be some low hanging fruit for small improvements, but I think we got all the major optimizations. In the cuDNN paper Appleyard mentions that they are using a different cuBLAS API than the public one, which might explain a portion of the margin. We might also try different input sizes which might gives us an edge against cuDNN with right parameters.

Tested correctness for shorter sequences with same floating point accuracy as before.