### PR TITLE
install_submodules.sh seems to need absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This section provides a short description of how to build Tiramisu.  A more deta
 2) Get and install Tiramisu submodules (ISL, LLVM and Halide).  This step may take between few minutes to few hours (downloading and compiling LLVM is time consuming).
 
         ./utils/scripts/install_submodules.sh <TIRAMISU_ROOT_DIR>
+        # make sure <TIRAMISU_ROOT_DIR> is absolute path!
 
 3) Optional: configure the tiramisu build by editing `configure.cmake`.  Needed only if you want to generate MPI or GPU code, or if you want to run the BLAS benchmarks.  A description of what each variable is and how it should be set is provided in comments in `configure.cmake`.
 


### PR DESCRIPTION
Without absolute path as argument, the script fails to cd in llvm directory.