### PR TITLE
Add simple optimizations to DenseNet block

### DIFF
--- a/benchmarks/DNN/blocks/DenseNetBlock/configure.h
+++ b/benchmarks/DNN/blocks/DenseNetBlock/configure.h
@@ -14,7 +14,7 @@
 #endif
 
 // DenseNet blocks are numbered from 1 to 4
-#define BLOCK_NUMBER 1
+#define BLOCK_NUMBER 2
 
 // Growth Rate of the block (see the original DenseNet paper for a definition)
 // This block receives an input tensor of size NxNx4*GR and outputs a tensor of size NxNxGR
@@ -40,7 +40,7 @@
 // If this is defined, print 10 array elements only
 #define PRINT_ONLY_10 0
 
-#define NB_TESTS 1
+#define NB_TESTS 11
 
 #ifdef __cplusplus
 double median(std::vector<std::chrono::duration<double, std::milli>> scores)

--- a/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
@@ -33,30 +33,24 @@ int main()
     input bn_scale("bn_scale", {z}, p_float64);
     input bn_shift("bn_shift", {z}, p_float64);
 
+    var y_pad("y_pad", 0, C_N + 2), x_pad("x_pad", 0, C_N + 2);
+    computation init_workspace("init_workspace", {n, z, y_pad, x_pad}, cast(p_float64, expr(0)));
+
     // Compute the sum over the features dimension (z)
     computation input_sum_init("input_sum_init", {z}, cast(p_float64, expr(0)));
-    computation input_sum("input_sum", {n, z, y, x}, input_sum_init(z) + c_input(n, z, y, x));
+    computation input_sum("input_sum", {z, n, y, x}, input_sum_init(z) + c_input(n, z, y, x));
 
     // Compute the sum of squares over the features dimension (z)
     computation input_sum_squares_init("input_sum_squares_init", {z}, cast(p_float64, expr(0)));
-    computation input_sum_squares("input_sum_squares", {n, z, y, x}, input_sum_squares_init(z) + c_input(n, z, y, x) * c_input(n, z, y, x));
+    computation input_sum_squares("input_sum_squares", {z, n, y, x}, input_sum_squares_init(z) + c_input(n, z, y, x) * c_input(n, z, y, x));
 
-    computation input_mean("input_mean", {z}, input_sum(C_BATCH_SIZE - 1, z, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS));
-    computation input_sd("input_sd", {z}, expr(o_sqrt, input_sum_squares(C_BATCH_SIZE - 1, z, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS) - input_mean(z) * input_mean(z) + EPSILON));
-    computation bn("bn", {n, z, y, x}, bn_scale(z) * ((c_input(n, z, y, x) - input_mean(z)) / input_sd(z)) + bn_shift(z));
+    computation input_mean("input_mean", {z}, input_sum(z, C_BATCH_SIZE - 1, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS));
+    computation input_sd("input_sd", {z}, expr(o_sqrt, input_sum_squares(z, C_BATCH_SIZE - 1, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS) - input_mean(z) * input_mean(z) + EPSILON));
+    computation bn("bn", {z, n, y, x}, bn_scale(z) * ((c_input(n, z, y, x) - input_mean(z)) / input_sd(z)) + bn_shift(z));
 
     // ReLU computation
-    computation relu("relu", {n, z, y, x}, expr(o_max, cast(p_float64, 0), bn(n, z, y, x)));
-
-    // Apply padding to ReLU
-    var y_pad("y_pad", 0, C_N + 2), x_pad("x_pad", 0, C_N + 2);
+    computation relu("relu", {z, n, y, x}, expr(o_max, cast(p_float64, 0), bn(z, n, y, x)));
     computation relu_padded("relu_padded", {n, z, y_pad, x_pad}, p_float64, false);
-
-    var pad_iter("pad_iter", 0, C_N + 2);
-    computation pad_top("pad_top", {n, z, pad_iter}, cast(p_float64, expr(0)));
-    computation pad_bottom("pad_bottom", {n, z, pad_iter}, cast(p_float64, expr(0)));
-    computation pad_left("pad_left", {n, z, pad_iter}, cast(p_float64, expr(0)));
-    computation pad_right("pad_right", {n, z, pad_iter}, cast(p_float64, expr(0)));
 
     // Convolution computation
     var k_x("k_x", 0, K_X), k_y("k_y", 0, K_Y), fin("fin", 0, 4*GR), fout("fout", 0, GR);
@@ -64,33 +58,30 @@ int main()
     input conv_bias("conv_bias", {fout}, p_float64);
 
     var fh("fh", 0, K_Y), fw("fw", 0, K_X), fk("fk", 0, 4*GR);
-    computation init_output("init_output", {n, fout, y, x}, cast(p_float64, expr(0)));
-    computation apply_filter("apply_filter", {n, fout, y, x, fh, fw, fk}, init_output(n, fout, y, x) + relu_padded(n, fk, y + fh, x + fw)*conv_filter(fout, fk, fh, fw));
-
-    computation conv("conv", {n, fout, y, x}, conv_bias(fout) + apply_filter(n, fout, y, x, K_Y - 1, K_X - 1, 4*GR - 1));
-
+    computation init_output("init_output", {n, fout, y, x}, conv_bias(fout));
+    computation conv("conv", {n, fout, y, x, fk, fh, fw}, init_output(n, fout, y, x) + relu_padded(n, fk, y + fh, x + fw)*conv_filter(fout, fk, fh, fw));
+    
     // -------------------------------------------------------
     // Layer II
     // -------------------------------------------------------
+    input_sum_init.after(init_workspace, computation::root);
     input_sum_squares_init.after(input_sum_init, z);
     
-    input_sum.after(input_sum_squares_init, computation::root);
+    input_sum.after(input_sum_squares_init, z);
     input_sum_squares.after(input_sum, x);
 
-    input_mean.after(input_sum, computation::root);
+    input_mean.after(input_sum, z);
     input_sd.after(input_mean, z);
 
-    bn.after(input_sd, computation::root);
+    bn.after(input_sd, z);
     relu.after(bn, x);
+    relu.tag_parallel_level(z);
 
-    pad_top.after(relu, computation::root);
-    pad_bottom.after(pad_top, pad_iter);
-    pad_left.after(pad_bottom, pad_iter);
-    pad_right.after(pad_left, pad_iter);
+    init_output.after(relu, computation::root);
+    conv.after(init_output, x);
 
-    init_output.after(pad_right, n);
-    apply_filter.after(init_output, x);
-    conv.after(apply_filter, x);
+    conv.tag_unroll_level(fw);
+    conv.tag_parallel_level(fout);
 
     // -------------------------------------------------------
     // Layer III
@@ -118,6 +109,8 @@ int main()
     conv_filter.store_in(&conv_filter_buf);
     conv_bias.store_in(&conv_bias_buf);
     
+    init_workspace.store_in(&workspace_buf);
+
     input_sum_init.store_in(&input_mean_buf);
     input_sum.store_in(&input_mean_buf, {z});
     input_mean.store_in(&input_mean_buf);
@@ -131,17 +124,9 @@ int main()
     bn.store_in(&workspace_buf, {n, z, y + 1, x + 1});
     relu.store_in(&workspace_buf, {n, z, y + 1, x + 1});
     relu_padded.store_in(&workspace_buf);
-
-    // We map these calculations to the workspace buffer
-    // in order to fill the padding region with zeros.
-    pad_top.store_in(&workspace_buf, {n, z, pad_iter, 0});
-    pad_bottom.store_in(&workspace_buf, {n, z, pad_iter, C_N + 1});
-    pad_left.store_in(&workspace_buf, {n, z, 0, pad_iter});
-    pad_right.store_in(&workspace_buf, {n, z, C_N + 1, pad_iter});
-
+    
     init_output.store_in(&output_buf);
-    apply_filter.store_in(&output_buf, {n, fout, y, x});
-    conv.store_in(&output_buf);
+    conv.store_in(&output_buf, {n, fout, y, x});
 
     // -------------------------------------------------------
     // Code Generation


### PR DESCRIPTION
I have added some simple optimizations to the DenseNet block benchmark :

1. Fuse some loops (Batch normalization and ReLU are now done in a single loop).
2. Unroll the inner-most level of the convolution loop (this level applies the convolution filter over the x-axis, it just does 3 iterations as the filter size is 3x3).
3. Tag two loop levels to be parallelized.

I have tested execution time with the following parameters : 

BATCH_SIZE = 32
Width and Height = 28
Input channels = 128
Output channels = 32

The results on my laptop are : 

Intel MKL : 256ms.
Tiramisu : 551ms.