### PR TITLE
Optimize convolution and BN in DenseNet block

### DIFF
--- a/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
@@ -103,7 +103,7 @@ int main()
         conv.vectorize(x, 4);
     }
 
-    else if (BLOCK_NUMBER == 3) {
+    else {
         init_output.vectorize(x, 2);
         conv.vectorize(x, 2);
     }

--- a/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
@@ -38,18 +38,18 @@ int main()
 
     // Compute the sum over the features dimension (z)
     computation input_sum_init("input_sum_init", {z}, cast(p_float64, expr(0)));
-    computation input_sum("input_sum", {z, n, y, x}, input_sum_init(z) + c_input(n, z, y, x));
+    computation input_sum("input_sum", {n, z, y, x}, input_sum_init(z) + c_input(n, z, y, x));
 
     // Compute the sum of squares over the features dimension (z)
     computation input_sum_squares_init("input_sum_squares_init", {z}, cast(p_float64, expr(0)));
-    computation input_sum_squares("input_sum_squares", {z, n, y, x}, input_sum_squares_init(z) + c_input(n, z, y, x) * c_input(n, z, y, x));
+    computation input_sum_squares("input_sum_squares", {n, z, y, x}, input_sum_squares_init(z) + c_input(n, z, y, x) * c_input(n, z, y, x));
 
-    computation input_mean("input_mean", {z}, input_sum(z, C_BATCH_SIZE - 1, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS));
-    computation input_sd("input_sd", {z}, expr(o_sqrt, input_sum_squares(z, C_BATCH_SIZE - 1, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS) - input_mean(z) * input_mean(z) + EPSILON));
-    computation bn("bn", {z, n, y, x}, bn_scale(z) * ((c_input(n, z, y, x) - input_mean(z)) / input_sd(z)) + bn_shift(z));
+    computation input_mean("input_mean", {z}, input_sum(C_BATCH_SIZE - 1, z, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS));
+    computation input_sd("input_sd", {z}, expr(o_sqrt, input_sum_squares(C_BATCH_SIZE - 1, z, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS) - input_mean(z) * input_mean(z) + EPSILON));
+    computation bn("bn", {n, z, y, x}, bn_scale(z) * ((c_input(n, z, y, x) - input_mean(z)) / input_sd(z)) + bn_shift(z));
 
     // ReLU computation
-    computation relu("relu", {z, n, y, x}, expr(o_max, cast(p_float64, 0), bn(z, n, y, x)));
+    computation relu("relu", {n, z, y, x}, expr(o_max, cast(p_float64, 0), bn(n, z, y, x)));
     computation relu_padded("relu_padded", {n, z, y_pad, x_pad}, p_float64, false);
 
     // Convolution computation
@@ -64,24 +64,45 @@ int main()
     // -------------------------------------------------------
     // Layer II
     // -------------------------------------------------------
-    input_sum_init.after(init_workspace, computation::root);
-    input_sum_squares_init.after(input_sum_init, z);
-    
-    input_sum.after(input_sum_squares_init, z);
-    input_sum_squares.after(input_sum, x);
+    init_workspace.then(input_sum_init, computation::root)
+                  .then(input_sum_squares_init, z)
+                  .then(input_sum, computation::root)
+                  .then(input_sum_squares, x)
+                  .then(input_mean, computation::root)
+                  .then(input_sd, z)
+                  .then(bn, computation::root)
+                  .then(relu, x)
+                  .then(init_output, computation::root)
+                  .then(conv, fout);
 
-    input_mean.after(input_sum, z);
-    input_sd.after(input_mean, z);
+    conv.tag_parallel_level(n);
 
-    bn.after(input_sd, z);
-    relu.after(bn, x);
-    relu.tag_parallel_level(z);
+    conv.interchange(x, fk);
+    conv.interchange(y, fk);
 
-    init_output.after(relu, computation::root);
-    conv.after(init_output, x);
+    if (BLOCK_NUMBER == 1) {
+        init_output.split(fout, 8);
+        conv.split(fout, 8);
 
-    conv.tag_unroll_level(fw);
-    conv.tag_parallel_level(fout);
+        init_output.vectorize(x, 8);
+        conv.vectorize(x, 8);
+
+        conv.tag_unroll_level(fw);
+        conv.tag_unroll_level(fh);
+    }
+
+    else if (BLOCK_NUMBER == 2) {
+        init_output.split(fout, 8);
+        conv.split(fout, 8);
+
+        init_output.vectorize(x, 4);
+        conv.vectorize(x, 4);
+    }
+
+    else if (BLOCK_NUMBER == 3) {
+        init_output.vectorize(x, 2);
+        conv.vectorize(x, 2);
+    }
 
     // -------------------------------------------------------
     // Layer III


### PR DESCRIPTION
I have added the convolution optimizations, and tagged a loop in batch normalization to be parallelized.

The convolution optimizations are : loop interchange, parallelize, split and vectorize. I have tried to tune the parameters according to the different sizes of the input.

For BN, I should see how to optimize it better.

Here are the results that I have, the input and output channels are always respectively 128 and 32. **N** represents the width and height of the input. As you see, for N = 7, Intel MKL code outperforms TIramisu code, I should investigate this.

-----------------------------------

BATCH_SIZE = 100
N = 56
MKL : 3366.581 ms
Tiramisu : 2075.63 ms

-----------------------------------

BATCH_SIZE = 32
N = 56
MKL : 1056.836 ms
Tiramisu : 666.363 ms

-----------------------------------

BATCH_SIZE = 8
N = 56
MKL : 264.575 ms
Tiramisu : 155.588 ms

-----------------------------------

BATCH_SIZE = 100
N = 28
MKL : 809.433 ms
Tiramisu : 555.059 ms

-----------------------------------

BATCH_SIZE = 32
N = 28
MKL : 256.138 ms
Tiramisu : 171.093 ms

-----------------------------------

BATCH_SIZE = 8
N = 28
MKL : 64.023 ms
Tiramisu : 42.788 ms

-----------------------------------

BATCH_SIZE = 100
N = 14
MKL : 186.153 ms
Tiramisu : 144.713 ms

-----------------------------------

BATCH_SIZE = 32
N = 14
MKL : 62.888 ms
Tiramisu : 48.116 ms

-----------------------------------

BATCH_SIZE = 8
N = 14
MKL : 15.047 ms
Tiramisu : 12.055 ms

-----------------------------------

BATCH_SIZE = 100
N = 7
MKL : 47.477 ms
Tiramisu : 50.560 ms

-----------------------------------

BATCH_SIZE = 32
N = 7
MKL : 15.301 ms
Tiramisu : 16.825 ms

-----------------------------------

BATCH_SIZE = 8
N = 7
MKL : 1.798 ms
Tiramisu : 4.253 ms