### PR TITLE
Windows fix

### DIFF
--- a/src/tiramisu_codegen_cuda.cpp
+++ b/src/tiramisu_codegen_cuda.cpp
@@ -29,6 +29,14 @@
 #include <fstream>
 #include <memory>
 
+#ifdef _WIN32
+#define popen _popen
+#define pclose _pclose
+
+#include <direct.h>
+#define getcwd _getcwd
+#endif
+
 namespace tiramisu {
 
 tiramisu::expr replace_original_indices_with_transformed_indices(tiramisu::expr exp,

--- a/src/tiramisu_codegen_halide_to_c.cpp
+++ b/src/tiramisu_codegen_halide_to_c.cpp
@@ -71,7 +71,7 @@ string halide_type_to_tiramisu_type_str(Type type)
         }
         else
         {
-            tiramisu::error("Floats other than 32 and 64 bits are not suppored in Tiramisu.", true);
+            ERROR("Floats other than 32 and 64 bits are not suppored in Tiramisu.", true);
         }
     }
     else if (type.is_bool())
@@ -80,7 +80,7 @@ string halide_type_to_tiramisu_type_str(Type type)
     }
     else
     {
-        tiramisu::error("Halide type cannot be translated to Tiramisu type.", true);
+        ERROR("Halide type cannot be translated to Tiramisu type.", true);
     }
     return "tiramisu::p_none";
 }
@@ -117,7 +117,7 @@ private:
 
     void error() const
     {
-        tiramisu::error("Can't convert to tiramisu expr.", true);
+        ERROR("Can't convert to tiramisu expr.", true);
     }
 
     void push_loop_dim(const For *op)

--- a/src/tiramisu_core.cpp
+++ b/src/tiramisu_core.cpp
@@ -17,16 +17,10 @@
 
 namespace tiramisu
 {
-bool global::auto_data_mapping;
-function *global::implicit_fct;
-
-primitive_t global::loop_iterator_type = p_int32;
-
+int send::next_msg_tag = 0;
+std::set<int> tiramisu::xfer_prop::xfer_prop_ids;
 // Used for the generation of new variable names.
 int id_counter = 0;
-
-const var computation::root = var("root");
-
 static int next_dim_name = 0;
 
 std::string generate_new_variable_name();
@@ -7039,8 +7033,6 @@ void tiramisu::computation::storage_fold(tiramisu::var L0_var, int factor)
     DEBUG_INDENT(-4);
 }
 
-std::set<int> tiramisu::xfer_prop::xfer_prop_ids;
-
 tiramisu::xfer_prop::xfer_prop() { }
 
 tiramisu::xfer_prop::xfer_prop(tiramisu::primitive_t dtype,
@@ -7227,8 +7219,6 @@ std::string create_send_func_name(const xfer_prop chan)
     assert(false && "Communication must be either MPI or CUDA!");
     return "";
 }
-
-int send::next_msg_tag = 0;
 
 tiramisu::send::send(std::string iteration_domain_str, tiramisu::computation *producer, tiramisu::expr rhs,
                      xfer_prop prop, bool schedule_this, std::vector<expr> dims, tiramisu::function *fct) :

--- a/src/tiramisu_core.cpp
+++ b/src/tiramisu_core.cpp
@@ -11,6 +11,10 @@
 #include <tiramisu/debug.h>
 #include <tiramisu/core.h>
 
+#ifdef _WIN32
+#include <iso646.h>
+#endif
+
 namespace tiramisu
 {
 bool global::auto_data_mapping;

--- a/src/tiramisu_core.cpp
+++ b/src/tiramisu_core.cpp
@@ -23,6 +23,12 @@ std::set<int> tiramisu::xfer_prop::xfer_prop_ids;
 int id_counter = 0;
 static int next_dim_name = 0;
 
+bool global::auto_data_mapping = false;
+primitive_t global::loop_iterator_type = p_int32;
+function *global::implicit_fct;
+std::unordered_map<std::string, var> var::declared_vars;
+const var computation::root = var("root");
+
 std::string generate_new_variable_name();
 void project_out_static_dimensions(isl_set*& set);
 

--- a/src/tiramisu_cuda_wrappers.cpp
+++ b/src/tiramisu_cuda_wrappers.cpp
@@ -5,6 +5,7 @@
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <iostream>
+#include <sstream>
 #include "cublas_v2.h"
 
 using size_type = uint64_t;

--- a/src/tiramisu_debug.cpp
+++ b/src/tiramisu_debug.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <sstream>
 
 namespace tiramisu
 {

--- a/src/tiramisu_expr.cpp
+++ b/src/tiramisu_expr.cpp
@@ -3,11 +3,6 @@
 
 namespace tiramisu
 {
-bool global::auto_data_mapping = false;
-primitive_t global::loop_iterator_type = p_int32;
-function *global::implicit_fct;
-std::unordered_map<std::string, var> var::declared_vars;
-const var computation::root = var("root");
 
 tiramisu::expr& tiramisu::expr::operator=(tiramisu::expr const & e)
 {

--- a/src/tiramisu_expr.cpp
+++ b/src/tiramisu_expr.cpp
@@ -3,6 +3,11 @@
 
 namespace tiramisu
 {
+bool global::auto_data_mapping = false;
+primitive_t global::loop_iterator_type = p_int32;
+function *global::implicit_fct;
+std::unordered_map<std::string, var> var::declared_vars;
+const var computation::root = var("root");
 
 tiramisu::expr& tiramisu::expr::operator=(tiramisu::expr const & e)
 {
@@ -138,9 +143,6 @@ tiramisu::expr tiramisu::expr::copy() const
 {
     return (*this);
 }
-
-
-std::unordered_map<std::string, var> tiramisu::var::declared_vars;
 
 expr cast(primitive_t tT, const expr & e) {
     if (e.get_data_type() == tT)


### PR DESCRIPTION
Include files fix affect MSVC only.

Static initialization order fix affects both MSVC and MinGW GCC. Before that change there were some runtime errors at the library initialization stage:
https://isocpp.org/wiki/faq/ctors#static-init-order
