### PR TITLE
Fuse BN-ReLU with convolution in DenseNet block

### DIFF
--- a/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
@@ -33,9 +33,6 @@ int main()
     input bn_scale("bn_scale", {z}, p_float64);
     input bn_shift("bn_shift", {z}, p_float64);
 
-    var y_pad("y_pad", 0, C_N + 2), x_pad("x_pad", 0, C_N + 2);
-    computation init_workspace("init_workspace", {n, z, y_pad, x_pad}, cast(p_float64, expr(0)));
-
     // Compute the sum over the features dimension (z)
     computation input_sum_init("input_sum_init", {z}, cast(p_float64, expr(0)));
     computation input_sum("input_sum", {n, z, y, x}, input_sum_init(z) + c_input(n, z, y, x));
@@ -47,39 +44,42 @@ int main()
     computation input_mean("input_mean", {z}, input_sum(C_BATCH_SIZE - 1, z, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS));
     computation input_sd("input_sd", {z}, expr(o_sqrt, input_sum_squares(C_BATCH_SIZE - 1, z, C_N - 1, C_N - 1) / cast(p_float64, C_NB_ELEMENTS) - input_mean(z) * input_mean(z) + EPSILON));
     
+    var y_pad("y_pad", 0, C_N + 2), x_pad("x_pad", 0, C_N + 2);
+    computation init_workspace("init_workspace", {n, z, y_pad, x_pad}, cast(p_float64, expr(0)));
     computation bn("bn", {n, z, y, x}, bn_scale(z) * ((c_input(n, z, y, x) - input_mean(z)) / input_sd(z)) + bn_shift(z));
 
     // ReLU computation
     computation relu("relu", {n, z, y, x}, expr(o_max, cast(p_float64, 0), bn(n, z, y, x)));
-    computation relu_padded("relu_padded", {n, z, y_pad, x_pad}, p_float64, false);
+    view relu_padded("relu_padded", {n, z, y_pad, x_pad}, p_float64);
 
     // Convolution computation
     var k_x("k_x", 0, K_X), k_y("k_y", 0, K_Y), fout("fout", 0, GR);
-    input conv_filter("conv_filter", {z, fout, k_y, k_x}, p_float64);
+    input conv_filter("conv_filter", {fout, z, k_y, k_x}, p_float64);
     input conv_bias("conv_bias", {fout}, p_float64);
 
     computation init_output("init_output", {n, fout, y, x}, conv_bias(fout));
-    computation conv("conv", {n, fout, y, x, z, k_y, k_x}, init_output(n, fout, y, x) + relu_padded(n, z, y + k_y, x + k_x)*conv_filter(z, fout, k_y, k_x));
+    computation conv("conv", {n, fout, y, x, z, k_y, k_x}, init_output(n, fout, y, x) + relu_padded(n, z, y + k_y, x + k_x)*conv_filter(fout, z, k_y, k_x));
     
     // -------------------------------------------------------
     // Layer II
     // -------------------------------------------------------
-    init_workspace.then(init_output, computation::root)
-                  .then(input_sum_init, computation::root)
-                  .then(input_sum_squares_init, z)
-                  .then(input_sum, computation::root)
-                  .then(input_sum_squares, x)
-                  .then(input_mean, computation::root)
-                  .then(input_sd, z)
-                  .then(bn, computation::root)
-                  .then(relu, x)
-                  .then(conv, computation::root);
-
-    if (BLOCK_NUMBER != 4)
-        bn.tag_parallel_level(n);
-        
-    conv.tag_parallel_level(n);
     conv.interchange(fout, z);
+
+    init_output.then(input_sum_init, computation::root)
+               .then(input_sum_squares_init, z)
+               .then(input_sum, computation::root)
+               .then(input_sum_squares, x)
+               .then(input_mean, computation::root)
+               .then(input_sd, z)
+               .then(init_workspace, computation::root)
+               .then(bn, z)
+               .then(relu, x)
+               .then(conv, z);
+
+    if (LARGE_DATA_SET == 1)
+        init_output.tag_parallel_level(n);
+
+    conv.tag_parallel_level(n);
 
     if (BLOCK_NUMBER == 1) {
         conv.vectorize(x, 8);
@@ -116,7 +116,7 @@ int main()
 
     // We use this buffer as a temporary buffer to store BN and ReLU results
     // This buffer is padded (its width and height are C_N + 2) so as to prepare it for convolution
-    buffer workspace_buf("workspace_buf", {C_BATCH_SIZE, 4*GR, C_N + 2, C_N + 2}, p_float64, a_temporary);
+    buffer workspace_buf("workspace_buf", {C_BATCH_SIZE, C_N + 2, C_N + 2}, p_float64, a_temporary);
 
     buffer output_buf("output_buf", {C_BATCH_SIZE, GR, C_N, C_N}, p_float64, a_output);
 
@@ -124,10 +124,10 @@ int main()
     c_input.store_in(&input_buf);
     bn_scale.store_in(&bn_scale_buf);
     bn_shift.store_in(&bn_shift_buf);
-    conv_filter.store_in(&conv_filter_buf);
+    conv_filter.store_in(&conv_filter_buf, {z, fout, k_y, k_x});
     conv_bias.store_in(&conv_bias_buf);
     
-    init_workspace.store_in(&workspace_buf);
+    init_workspace.store_in(&workspace_buf, {n, y_pad, x_pad});
 
     input_sum_init.store_in(&input_mean_buf);
     input_sum.store_in(&input_mean_buf, {z});
@@ -139,9 +139,9 @@ int main()
 
     // We shift the BN and ReLU computations, so as to avoid to
     // compute on the padding region of workspace_buf.
-    bn.store_in(&workspace_buf, {n, z, y + 1, x + 1});
-    relu.store_in(&workspace_buf, {n, z, y + 1, x + 1});
-    relu_padded.store_in(&workspace_buf);
+    bn.store_in(&workspace_buf, {n, y + 1, x + 1});
+    relu.store_in(&workspace_buf, {n, y + 1, x + 1});
+    relu_padded.store_in(&workspace_buf, {n, y_pad, x_pad});
     
     init_output.store_in(&output_buf);
     conv.store_in(&output_buf, {n, fout, y, x});

--- a/benchmarks/DNN/blocks/DenseNetBlock/wrapper_nn_block.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/wrapper_nn_block.cpp
@@ -17,7 +17,7 @@ int main()
     Halide::Buffer<int> parameters(2);
     Halide::Buffer<double> input(N, N, 4*GR, BATCH_SIZE);
     Halide::Buffer<double> bn_scale(4*GR), bn_shift(4*GR);
-    Halide::Buffer<double> conv_filter(K_X, K_Y, 4*GR, GR);
+    Halide::Buffer<double> conv_filter(K_X, K_Y, GR, 4*GR);
     Halide::Buffer<double> conv_bias(GR);
 
     Halide::Buffer<double> output(N, N, GR, BATCH_SIZE);
@@ -35,7 +35,7 @@ int main()
         for (int fin = 0; fin < 4*GR; ++fin)
             for (int k_y = 0; k_y < K_Y; ++k_y)
                 for (int k_x = 0; k_x < K_X; ++k_x)
-                    conv_filter(k_x, k_y, fin, fout) = ((double)(rand()%256 - 128)) / 127.f;
+                    conv_filter(k_x, k_y, fout, fin) = ((double)(rand()%256 - 128)) / 127.f;
 
     for (int fout = 0; fout < GR; ++fout)
         conv_bias(fout) = ((double)(rand()%256 - 128)) / 127.f;


### PR DESCRIPTION
I have fused BN-ReLU with convolution and got an improvement in performance. You can see the new execution times in the spreadsheet.

I have first tried a simpler method for the fusion, you can find how it looks in the pseudocode. Now I will try the method with split to see if it improves results.

Spreadsheet : https://docs.google.com/spreadsheets/d/18nbTBRIBDAmohslrup8Vs3ri-TgYpOh6SzI8ttzWn0o/edit?usp=sharing

Pseudocode : https://docs.google.com/document/d/1B0M-KnAisEUXoYuL5K_msVR5in3cLTn7mzRnWcq_KYc/edit?usp=sharing