### PR TITLE
Add syrk BLAS function without optimizations

### DIFF
--- a/benchmarks/linear_algebra/blas/level3/syrk/syrk_generator.cpp
+++ b/benchmarks/linear_algebra/blas/level3/syrk/syrk_generator.cpp
@@ -1,0 +1,112 @@
+#include <tiramisu/tiramisu.h>
+
+#include "benchmarks.h"
+
+using namespace tiramisu;
+
+/**
+*	Benchmark for BLAS SYRK
+*     out = alpha * A * A' + beta * C
+*
+*     A : a N by K matrix
+*     C : a symmetric N by N matrix
+*     alpha, beta : scalars
+*     A' is the transpose of A
+*/
+/**
+	We will make a tiramisu implementation of this code :
+	for(int i = 0; i<N; i++){
+		for(int j = 0; j<=i; j++){
+			int tmp = 0;
+			for(k=0; k<K; k++)
+				tmp += A[i][k] * A[j][k];
+			RESULT[i][j] = alpha * tmp + beta* C[i][j];
+		}
+	}
+*/
+
+int main(int argc, char **argv)
+{
+	tiramisu::init();
+	
+	function syrk("syrk");
+	// -------------------------------------------------------
+	// Layer I
+	// -------------------------------------------------------
+	computation SIZES("{SIZES[e]: 0<=e<2}", expr(), false, p_float64, &syrk);
+	//Constants
+	constant NN("NN", SIZES(0), p_int32, true, NULL, 0, &syrk);
+	constant KK("KK", SIZES(1), p_int32, true, NULL, 0, &syrk);
+	
+	//Iteration variables
+	var i("i"), j("j"), k("k");
+	
+	//Inputs
+	computation A("[NN,KK]->{A[i,k]: 0<=i<NN and 0<=k<KK}", expr(), false,  p_float64, &syrk);
+	computation C("[NN]->{C[i,j]: 0<=i<NN and 0<=j<NN}", expr(), false, p_float64, &syrk);
+	computation alpha("{alpha[0]}", expr(), false, p_float64, &syrk);
+	computation beta("{beta[0]}", expr(), false, p_float64, &syrk);
+	
+	//Computations
+	computation result_init("[NN]->{result_init[i,j]: 0<=i<NN and 0<=j<=i}", expr(cast(p_float64, 0)), true, p_float64, &syrk);
+	computation mat_mul("[NN,KK]->{mat_mul[i,j,k]: 0<=i<NN and 0<=j<=i and 0<=k<KK}", expr(), true, p_float64, &syrk);
+	computation mult_alpha("[NN]->{mult_alpha[i,j]: 0<=i<NN and 0<=j<=i}", expr(), true, p_float64, &syrk);
+	computation add_beta_C("[NN]->{add_beta_C[i,j]: 0<=i<NN and 0<=j<=i}", expr(), true, p_float64, &syrk);
+	
+	computation copy_symmetric_part("[NN]->{copy_symmetric_part[i,j]: 0<=i<NN and i<j<NN}", expr(), true, p_float64, &syrk);
+	
+	mat_mul.set_expression(expr(mat_mul(i, j, k-1) + A(i, k) * A(j, k)));
+	mult_alpha.set_expression(expr(alpha(0) * mat_mul(i, j, NN-1)));
+	add_beta_C.set_expression(expr(mult_alpha(i, j) + beta(0) * C(i, j)));
+	
+	copy_symmetric_part.set_expression(expr(add_beta_C(j, i)));
+	
+	// -------------------------------------------------------
+	// Layer II
+	// -------------------------------------------------------
+	copy_symmetric_part.after(add_beta_C, computation::root_dimension);
+	add_beta_C.after(mult_alpha, i);
+	mult_alpha.after(mat_mul, i);
+	mat_mul.after(result_init, i);
+	
+	// -------------------------------------------------------
+	// Layer III
+	// -------------------------------------------------------
+	//Input Buffers
+	buffer buf_SIZES("buf_SIZES", {2}, tiramisu::p_int32, a_input, &syrk);
+	
+	buffer buf_A("buf_A", {NN,KK}, p_float64, a_input, &syrk);
+	buffer buf_C("buf_C", {NN,NN}, p_float64, a_input, &syrk);
+	buffer buf_alpha("buf_alpha", {1}, p_float64, a_input, &syrk);
+	buffer buf_beta("buf_beta", {1}, p_float64, a_input, &syrk);
+	
+	//Output Buffers
+	buffer buf_result("buf_result", {NN, NN}, p_float64, a_output, &syrk);
+	
+	//Store inputs
+	SIZES.set_access("{SIZES[e]->buf_SIZES[e]: 0<=e<2}");
+	
+	A.set_access("{A[i,k]->buf_A[i,k]}");
+	C.set_access("{C[i,j]->buf_C[i,j]}");
+	alpha.set_access("{alpha[0]->buf_alpha[0]}");
+	beta.set_access("{beta[0]->buf_beta[0]}");
+	
+	//Store computations
+	result_init.set_access("{result_init[i,j]->buf_result[i,j]}");
+	mat_mul.set_access("{mat_mul[i,j,k]->buf_result[i,j]}");
+	mult_alpha.set_access("{mult_alpha[i,j]->buf_result[i,j]}");
+	add_beta_C.set_access("{add_beta_C[i,j]->buf_result[i,j]}");
+	add_beta_C.set_access("{add_beta_C[j,i]->buf_result[j,i]}");
+	copy_symmetric_part.set_access("{copy_symmetric_part[i,j]->buf_result[i,j]}");
+	
+	// -------------------------------------------------------
+	// Code Generation
+	// -------------------------------------------------------
+	syrk.set_arguments({&buf_SIZES, &buf_A, &buf_C, &buf_alpha, &buf_beta, &buf_result});
+	syrk.gen_time_space_domain();
+	syrk.gen_isl_ast();
+	syrk.gen_halide_stmt();
+	syrk.gen_halide_obj("generated_syrk.o");
+	
+	return 0;
+}

--- a/benchmarks/linear_algebra/blas/level3/syrk/syrk_wrapper.cpp
+++ b/benchmarks/linear_algebra/blas/level3/syrk/syrk_wrapper.cpp
@@ -1,0 +1,133 @@
+#include "generated_syrk.o.h"
+
+#include "Halide.h"
+#include <tiramisu/utils.h>
+
+#include <iostream>
+#include "benchmarks.h"
+
+#define N_DIM N
+#define K_DIM K
+
+int syrk_ref(
+	const int NN,
+	const int KK,
+	const double * A,
+	const double * C,
+	const double * alpha,
+	const double * beta,
+		  double * result)
+{
+	int tmp;
+	for(int i = 0; i<NN; i++)
+	{
+		for(int j = 0; j<=i; j++)
+		{
+			tmp=0;
+			for(int k = 0; k<KK; k++)
+				tmp += A[i * KK + k] * A[j * KK + k];
+			result[i * NN + j] = alpha[0] * tmp + beta[0] * C[i * NN + j];
+		}
+	}
+  	//Copy the lower part of the matrix into the upper part
+  	for(int i=0; i<NN; i++)
+	{
+		for(int j = i+1; j<NN; j++)
+		{
+			result[i * NN + j] = result[j * NN + i];
+		}
+	}
+	return 0;
+}
+
+int main(int argc, char** argv)
+{
+	std::vector<std::chrono::duration<double, std::milli>> duration_vector_1;
+	std::vector<std::chrono::duration<double, std::milli>> duration_vector_2;
+	
+	bool run_ref = false;
+	bool run_tiramisu = false;
+	
+	const char* env_ref = std::getenv("RUN_REF");
+	if ((env_ref != NULL) && (env_ref[0] == '1'))
+		run_ref = true;
+	const char* env_tira = std::getenv("RUN_TIRAMISU");
+	if ((env_tira != NULL) && (env_tira[0] == '1'))
+		run_tiramisu = true;
+	
+	// ---------------------------------------------------------------------
+	// ---------------------------------------------------------------------
+	// ---------------------------------------------------------------------
+	
+	Halide::Buffer<int> SIZES(2);
+	SIZES(0) = N_DIM;
+	SIZES(1) = K_DIM;
+	
+	Halide::Buffer<double> b_A(N_DIM, K_DIM);
+	init_buffer(b_A, (double) 1);
+	
+	Halide::Buffer<double> b_C(N_DIM, N_DIM);
+	init_buffer(b_C, (double) 1);
+	
+	Halide::Buffer<double> b_alpha(1),b_beta(1);
+	init_buffer(b_alpha, (double) 3);
+	init_buffer(b_beta, (double) 2);
+	
+	Halide::Buffer<double> b_result(N_DIM, N_DIM), b_result_ref(N_DIM, N_DIM);
+	init_buffer(b_result, (double) 0);
+	/**
+		We have
+	    - A a N_DIM by K_DIM matrix of ones
+	    - C a N_DIM by N_DIM matrix of ones
+	    - alpha, beta scalars respectively equal to 3 and 2
+	*/
+	
+	//REFERENCE
+	{
+		for (int i = 0; i < NB_TESTS; i++)
+		{
+			init_buffer(b_result_ref, (double)0);
+			auto start1 = std::chrono::high_resolution_clock::now();
+			if (run_ref)
+				syrk_ref(SIZES(0), SIZES(1), b_A.data(), b_C.data(), b_alpha.data(), b_beta.data(), b_result_ref.data());
+			auto end1 = std::chrono::high_resolution_clock::now();
+			std::chrono::duration<double,std::milli> duration1 = end1 - start1;
+			duration_vector_1.push_back(duration1);
+		}
+	}
+	
+	//TIRAMISU
+	{
+		for (int i = 0; i < NB_TESTS; ++i)
+		{
+			auto start = std::chrono::high_resolution_clock::now();
+			if (run_tiramisu)
+				syrk(SIZES.raw_buffer(), b_A.raw_buffer(), b_C.raw_buffer(), b_alpha.raw_buffer(), b_beta.raw_buffer(), b_result.raw_buffer());
+			auto end = std::chrono::high_resolution_clock::now();
+			duration_vector_2.push_back(end - start);
+		}
+	}
+	
+	print_time("performance_CPU.csv", "syrk",
+				{"Ref", "Tiramisu"},
+				{median(duration_vector_1), median(duration_vector_2)});
+	
+	if (PRINT_OUTPUT)
+	{
+		if (run_tiramisu)
+		{
+			std::cout << "Tiramisu " << std::endl;
+			print_buffer(b_result);
+		}
+		if (run_ref)
+		{
+			std::cout << "Reference " << std::endl;
+			print_buffer(b_result_ref);
+		}
+	}
+	
+	if (run_ref && run_tiramisu)
+		compare_buffers("syrk", b_result, b_result_ref);
+	
+	return 0;
+}


### PR DESCRIPTION
Hi,
Here's my implementation of SYRK using the old Tiramisu syntax : 
out = alpha * A * A' + beta * C

I have tried using the new Tiramisu syntax but didn't find how to make variables iterate according to another variable's value. I've tried 
`var i("i", 0, N);`
`var j("j", 0, i);`
But i had to declare many variables to get different iteration domains. Which got me into problems later.
So I wanted to know if this is valid using the new syntax.

Thank you very much.