### PR TITLE
Add optimizations to syrk and gemv blas functions

### DIFF
--- a/benchmarks/linear_algebra/blas/level2/gemv/gemv_generator.cpp
+++ b/benchmarks/linear_algebra/blas/level2/gemv/gemv_generator.cpp
@@ -2,6 +2,8 @@
 
 #include "benchmarks.h"
 
+#define UNROLL_FACTOR 64
+
 using namespace tiramisu;
 
 /**
@@ -59,7 +61,12 @@ int main(int argc, char **argv)
     add_y.after(mult_alpha, i);
     mult_alpha.after(sum_row, i);
     sum_row.after(result_init, i);
-
+	
+	//Unrolling
+    sum_row.unroll(j, UNROLL_FACTOR);
+	//Parallelization
+    sum_row.parallelize(i);
+	
     // -------------------------------------------------------
     // Layer III
     // -------------------------------------------------------

--- a/benchmarks/linear_algebra/blas/level2/gemv/gemv_generator.cpp
+++ b/benchmarks/linear_algebra/blas/level2/gemv/gemv_generator.cpp
@@ -62,9 +62,9 @@ int main(int argc, char **argv)
     mult_alpha.after(sum_row, i);
     sum_row.after(result_init, i);
 	
-	//Unrolling
+    //Unrolling
     sum_row.unroll(j, UNROLL_FACTOR);
-	//Parallelization
+    //Parallelization
     sum_row.parallelize(i);
 	
     // -------------------------------------------------------

--- a/benchmarks/linear_algebra/blas/level3/syrk/syrk_generator.cpp
+++ b/benchmarks/linear_algebra/blas/level3/syrk/syrk_generator.cpp
@@ -2,10 +2,12 @@
 
 #include "benchmarks.h"
 
+#define UNROLL_FACTOR 32
+
 using namespace tiramisu;
 
 /**
-*	Benchmark for BLAS SYRK
+*  Benchmark for BLAS SYRK
 *     out = alpha * A * A' + beta * C
 *
 *     A : a N by K matrix
@@ -69,6 +71,14 @@ int main(int argc, char **argv)
 	mult_alpha.after(mat_mul, i);
 	mat_mul.after(result_init, i);
 	
+#if TIRAMISU_LARGE
+	mat_mul.unroll(k, UNROLL_FACTOR);
+#endif
+
+	//Parallelization
+	mat_mul.parallelize(i);
+	copy_symmetric_part.parallelize(i);
+
 	// -------------------------------------------------------
 	// Layer III
 	// -------------------------------------------------------


### PR DESCRIPTION
Hi,

I've added some optimizations to GEMV : 
- Parallelized the outer loop.
- Unrolled the cumulative loop for MatrixRow * vector.

For SYRK, I've :
- Parallelized the outer loop.
- Unrolled cumulative loop for MatrixRow * MatrixColumn
 
I've also tried to vectorize loop "j" on mat_mul. After testing, results seemed coherent. But i've found on the documentation that's not possible to vectorize loops with a number of interations less than the vector size, I preferred not to include it.

PS : the optimization I have tried is 
`mat_mul.vectorize(j, VECTOR_SIZE);`
Is it allowed ? Even though 
- 0 <= i < N 
- 0<= j <=i
And for i from 0 to VECTOR_SIZE -2, loop j will have less than VECTOR_SIZE iterations

Thank you