### PR TITLE
DenseNet block : Fuse BN-ReLU with CONV

### DIFF
--- a/benchmarks/DNN/blocks/DenseNetBlock/configure.h
+++ b/benchmarks/DNN/blocks/DenseNetBlock/configure.h
@@ -14,7 +14,7 @@
 #endif
 
 // DenseNet blocks are numbered from 1 to 4
-#define BLOCK_NUMBER 2
+#define BLOCK_NUMBER 1
 
 #define Z_BLOCKING 8
 #define FOUT_BLOCKING 8
@@ -27,7 +27,9 @@
 #define GR 32
 
 // Width and height of an input tensor
-#if BLOCK_NUMBER == 1
+#if BLOCK_NUMBER == 0
+    #define N 112
+#elif BLOCK_NUMBER == 1
     #define N 56
 #elif BLOCK_NUMBER == 2
     #define N 28
@@ -35,6 +37,13 @@
     #define N 14
 #elif BLOCK_NUMBER == 4
     #define N 7
+#endif
+
+// We fuse BN-Relu with CONV only for large N
+#if BLOCK_NUMBER <= 1
+    #define SCHEDULE_FUSION true
+#else
+    #define SCHEDULE_FUSION false
 #endif
 
 // Convolution kernel size
@@ -46,7 +55,7 @@
 // If this is defined, print 10 array elements only
 #define PRINT_ONLY_10 0
 
-#define NB_TESTS 11
+#define NB_TESTS 51
 
 #ifdef __cplusplus
 double median(std::vector<std::chrono::duration<double, std::milli>> scores)

--- a/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
@@ -150,10 +150,13 @@ int main()
         //n, z_b, fout_b, y, x, k_y, k_x, ffout, z_b
         conv.interchange(x, k_y);
         conv.interchange(x, k_x);
+        //n, z_b, fout_b, y, k_y, k_x, x, ffout, z_b
 
         if (BLOCK_NUMBER >= 1) {
+            //n, z_b, fout_b, y, k_y, k_x, x, ffout, z_b
             conv.interchange(y, k_y);
             conv.interchange(y, k_x);
+            //n, z_b, fout_b, k_y, k_x, y, x, ffout, z_b
         }
         
         conv.tag_parallel_level(n);

--- a/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_tiramisu.cpp
@@ -68,7 +68,7 @@ int main()
     computation bn("bn", bn_relu_iter_vars, expr(p_float32));
     computation relu("relu", bn_relu_iter_vars, expr(p_float32));
     
-    // Those two computations are not scheduled when fusion is disabled
+    // These two computations are not scheduled when fusion is disabled
     computation bn_prelude("bn_prelude", {n, z_b, x, zz}, expr(p_float32), SCHEDULE_FUSION);
     computation relu_prelude("relu_prelude", {n, z_b, x, zz}, expr(p_float32), SCHEDULE_FUSION);
 

--- a/benchmarks/DNN/blocks/DenseNetBlock/wrapper_nn_block.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/wrapper_nn_block.cpp
@@ -17,7 +17,7 @@ int main()
     Halide::Buffer<float> input(Z_BLOCKING, N, N, Z_NB_BLOCKS, BATCH_SIZE);
 
     Halide::Buffer<float> bn_scale(4*GR), bn_shift(4*GR);
-    Halide::Buffer<float> conv_filter(FOUT_BLOCKING, Z_BLOCKING, K_X, K_Y, Z_NB_BLOCKS, FOUT_NB_BLOCKS);
+    Halide::Buffer<float> conv_filter(Z_BLOCKING, FOUT_BLOCKING, K_X, K_Y, FOUT_NB_BLOCKS, Z_NB_BLOCKS);
     Halide::Buffer<float> conv_bias(GR);
 
     Halide::Buffer<float> output(FOUT_BLOCKING, N, N, FOUT_NB_BLOCKS, BATCH_SIZE);
@@ -35,7 +35,7 @@ int main()
         for (int z = 0; z < 4*GR; ++z)
             for (int k_y = 0; k_y < K_Y; ++k_y)
                 for (int k_x = 0; k_x < K_X; ++k_x)
-                    conv_filter(fout%FOUT_BLOCKING, z%Z_BLOCKING, k_x, k_y, z/Z_BLOCKING, fout/FOUT_BLOCKING) = ((float)(rand()%256 - 128)) / 127.f;
+                    conv_filter(z%Z_BLOCKING, fout%FOUT_BLOCKING, k_x, k_y, fout/FOUT_BLOCKING, z/Z_BLOCKING) = ((float)(rand()%256 - 128)) / 127.f;
 
     for (int fout = 0; fout < GR; ++fout)
         conv_bias(fout) = ((float)(rand()%256 - 128)) / 127.f;


### PR DESCRIPTION
Here I have fused BN-ReLU with CONV. The fusion can be enabled or disabled via `config.h`. By default, I enable it for large values of **N** (width and height of input), as it improves performances only when **N** is large enough.

You can find the numbers here : https://docs.google.com/spreadsheets/d/18nbTBRIBDAmohslrup8Vs3ri-TgYpOh6SzI8ttzWn0o/edit?usp=sharing