### PR TITLE
DNN benchmarks:  use rtclock for time measurement

### DIFF
--- a/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/configure.h
+++ b/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_RELU_MAXPOOL_CONF_HEADER_
 #define __CONV_RELU_MAXPOOL_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	0
 #define MEDIUM_DATA_SET	1
 #define SMALL_DATA_SET	0
@@ -40,7 +42,7 @@
 #define NB_TESTS 21
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -49,11 +51,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -85,5 +87,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/conv_relu_maxpool_generator_mkl.c
+++ b/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/conv_relu_maxpool_generator_mkl.c
@@ -146,18 +146,17 @@ int main()
 
     // Execute the block
     double times[NB_TESTS];
-    clock_t start, end;
+    double start, end;
 
     for (int i = 0; i < NB_TESTS; ++i) {
-        start = clock();
+        start = rtclock();
 
         CHECK_ERR(dnnExecute_F32(conv_primitive, (void**)res_conv), err);
         CHECK_ERR(dnnExecute_F32(relu_primitive, (void**)res_relu), err);
         CHECK_ERR(dnnExecute_F32(maxpool_primitive, (void**)res_maxpool), err);
 
-        end = clock();
-        double time_taken = ((double)(end - start) / CLOCKS_PER_SEC) * 1000;
-        times[i] = time_taken;
+        end = rtclock();
+        times[i] = (end - start) * 1000;
     }
 
     printf("\n\n\tConv-ReLU-MaxPool block time: %f ms.\n", median(NB_TESTS, times));

--- a/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/conv_relu_maxpool_generator_mkldnn.cpp
+++ b/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/conv_relu_maxpool_generator_mkldnn.cpp
@@ -14,7 +14,7 @@ using namespace std;
 void conv_relu_maxpool_block()
 {
     srand(1);
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
 
     engine cpu_engine(engine::kind::cpu, 0);
     stream cpu_stream(cpu_engine);
@@ -175,16 +175,15 @@ void conv_relu_maxpool_block()
 
     // Execute the network
     for (int i = 0; i < NB_TESTS; ++i) {
-        auto start = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         
         for (size_t j = 0; j < net.size(); ++j)
             net[j].execute(cpu_stream, net_args[j]);
 
         cpu_stream.wait();
 
-        auto end = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end - start;
-        duration_vector.push_back(duration);
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
 
     std::cout << "\n\n\tConv-ReLU-MaxPool block time : " << median(duration_vector) << " ms." << std::endl;

--- a/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/wrapper_nn_block.cpp
+++ b/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/wrapper_nn_block.cpp
@@ -12,7 +12,7 @@ using namespace std;
 int main()
 {
     srand(1);
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
 
     Halide::Buffer<float> input(FIN_BLOCKING, N, N, FIN_NB_BLOCKS, BATCH_SIZE);
 
@@ -41,7 +41,7 @@ int main()
 
     // Execute Tiramisu code
     for (int i = 0; i < NB_TESTS; ++i) {
-        auto start = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         conv_relu_maxpool_block(
             input.raw_buffer(), 
             conv_filter.raw_buffer(), 
@@ -49,9 +49,8 @@ int main()
             output.raw_buffer()
         );
         
-        auto end = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end - start;
-        duration_vector.push_back(duration);	
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);	
     }
 
     std::cout << "\t\tTiramisu Conv-ReLU-MaxPool block duration"

--- a/benchmarks/DNN/blocks/Conv-Relu-FC-Softmax/configure.h
+++ b/benchmarks/DNN/blocks/Conv-Relu-FC-Softmax/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_CONF_HEADER_
 #define __CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define SHOW_OUTPUT 0
 #define WRITE_RESULT_TO_FILE 1
 #define CHECK_CORRECTNESS 1
@@ -45,7 +47,7 @@
 #define NB_TESTS 100
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -54,11 +56,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -90,5 +92,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/blocks/Conv-Relu-FC-Softmax/conv_relu_fc_softmax_generator_mkldnn.cpp
+++ b/benchmarks/DNN/blocks/Conv-Relu-FC-Softmax/conv_relu_fc_softmax_generator_mkldnn.cpp
@@ -17,7 +17,7 @@ void conv_relu_fc_softmax()
 	int OUTPUT_N = (N - K + 2 * PADDING)/STRIDE + 1;
 	// Conv output flattened size (FC input size)
 	int FC_INPUT_SIZE = OUTPUT_N * OUTPUT_N * FOut;
-	std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+	std::vector<double> duration_vector;
 
 	engine cpu_engine(engine::kind::cpu, 0);
 	stream cpu_stream(cpu_engine);
@@ -260,15 +260,14 @@ void conv_relu_fc_softmax()
 
 	// Execute the network
 	for (int i = 0; i < NB_TESTS; ++i) {
-		auto start = std::chrono::high_resolution_clock::now();
+		double start = rtclock();
 		for (int j=0; j < net.size(); j++)
 			net[j].execute(cpu_stream, net_args[j]);
 
 		cpu_stream.wait();
 
-		auto end = std::chrono::high_resolution_clock::now();
-		std::chrono::duration<double, std::milli> duration = end - start;
-		duration_vector.push_back(duration);
+		double end = rtclock();
+		duration_vector.push_back((end - start) * 1000);
 	}
 
 	std::cout << "\n\n\tMKLDNN Conv-Relu-FC-Softmax time : " << median(duration_vector) << " ms." << std::endl;

--- a/benchmarks/DNN/blocks/Conv-Relu-FC-Softmax/conv_relu_fc_softmax_wrapper_tiramisu.cpp
+++ b/benchmarks/DNN/blocks/Conv-Relu-FC-Softmax/conv_relu_fc_softmax_wrapper_tiramisu.cpp
@@ -22,8 +22,7 @@ int main(int, char**)
 	Halide::Buffer<float> result(FC_OUTPUT_SIZE, BATCH_SIZE);
 	init_buffer(result, (float) 0);
 
-	std::vector<std::chrono::duration<double,std::milli>> duration_vector_1;
-	std::vector<std::chrono::duration<double,std::milli>> duration_vector_2;
+	std::vector<double> duration_vector;
 
 	for (int n=0; n < BATCH_SIZE; ++n)
 		for (int z=0; z < FIn; ++z)
@@ -57,16 +56,15 @@ int main(int, char**)
 
 	for (int i=0; i<NB_TESTS; i++)
 	{
-		auto start1 = std::chrono::high_resolution_clock::now();
+		double start = rtclock();
 
 		conv_relu_fc_softmax(input.raw_buffer(), filter.raw_buffer(), bias.raw_buffer(), fc_weights.raw_buffer(), fc_bias.raw_buffer(), result.raw_buffer());
 
-		auto end1 = std::chrono::high_resolution_clock::now();
-		std::chrono::duration<double,std::milli> duration = end1 - start1;
-		duration_vector_2.push_back(duration);
+		double end = rtclock();
+		duration_vector.push_back((end - start) * 1000);
 	}
 
-	std::cout << "\t\tTiramisu Conv-Relu-FC-Softmax" << ": " << median(duration_vector_2) << "; " << std::endl;
+	std::cout << "\t\tTiramisu Conv-Relu-FC-Softmax" << ": " << median(duration_vector) << "; " << std::endl;
 	if (SHOW_OUTPUT){
 		std::cout << "\t\tResult" << ": "<< std::endl;
 		for(int n=0; n<BATCH_SIZE; n++){
@@ -99,7 +97,7 @@ int main(int, char**)
 		for(int n=0; n<BATCH_SIZE; n++)
 			for(int z=0; z<FC_OUTPUT_SIZE; z++){
 				mkldnn_result >> tmp;
-				if (abs(result(z, n) - tmp) <= 0.000001)
+				if (std::abs(result(z, n) - tmp) <= 0.000001)
 					nb_correct++;
 			}
 

--- a/benchmarks/DNN/blocks/DenseNetBlock/configure.h
+++ b/benchmarks/DNN/blocks/DenseNetBlock/configure.h
@@ -1,6 +1,8 @@
 #ifndef __DENSENET_BLOCK_CONF_HEADER_
 #define __DENSENET_BLOCK_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	0
 #define MEDIUM_DATA_SET	1
 #define SMALL_DATA_SET	0
@@ -58,7 +60,7 @@
 #define NB_TESTS 51
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -67,11 +69,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -103,5 +105,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_mkl.c
+++ b/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_mkl.c
@@ -140,20 +140,19 @@ int main()
 
     // Execute the block
     double times[NB_TESTS];
-    clock_t start, end;
+    double start, end;
 
     for (int i = 0; i < NB_TESTS; ++i) {
         CHECK_ERR(dnnConversionExecute_F32(cv_usr_to_conv_input, input_buf, res_bn_relu[dnnResourceSrc]), err);
         
-        start = clock();
+        start = rtclock();
 
         CHECK_ERR(dnnExecute_F32(bn_primitive, (void**)res_bn_relu), err);
         CHECK_ERR(dnnExecute_F32(relu_primitive, (void**)res_bn_relu), err);
         CHECK_ERR(dnnExecute_F32(conv_primitive, (void**)res_conv), err);
 
-        end = clock();
-        double time_taken = ((double)(end - start) / CLOCKS_PER_SEC) * 1000;
-        times[i] = time_taken;
+        end = rtclock();
+        times[i] = (end - start) * 1000;
     }
 
     printf("\n\n\tDenseNet block time: %f ms.\n", median(NB_TESTS, times));

--- a/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_mkldnn.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/densenet_block_generator_mkldnn.cpp
@@ -14,7 +14,7 @@ using namespace mkldnn;
 void densenet_block()
 {
     srand(1);
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
 
     engine cpu_engine(engine::kind::cpu, 0);
     stream cpu_stream(cpu_engine);
@@ -182,16 +182,15 @@ void densenet_block()
 
     // Execute the network
     for (int i = 0; i < NB_TESTS; ++i) {
-        auto start = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         
         for (size_t j = 0; j < net.size(); ++j)
             net[j].execute(cpu_stream, net_args[j]);
 
         cpu_stream.wait();
 
-        auto end = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end - start;
-        duration_vector.push_back(duration);
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
 
     std::cout << "\n\n\tDenseNet block time : " << median(duration_vector) << " ms." << std::endl;

--- a/benchmarks/DNN/blocks/DenseNetBlock/wrapper_nn_block.cpp
+++ b/benchmarks/DNN/blocks/DenseNetBlock/wrapper_nn_block.cpp
@@ -12,7 +12,7 @@ using namespace std;
 int main()
 {
     srand(1);
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
 
     Halide::Buffer<float> input(Z_BLOCKING, N, N, Z_NB_BLOCKS, BATCH_SIZE);
 
@@ -50,7 +50,7 @@ int main()
 
     // Execute Tiramisu code
     for (int i = 0; i < NB_TESTS; ++i) {
-        auto start = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         densenet_block(
             input.raw_buffer(), 
             bn_scale.raw_buffer(), 
@@ -60,9 +60,8 @@ int main()
             output.raw_buffer()
         );
         
-        auto end = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end - start;
-        duration_vector.push_back(duration);	
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);	
     }
 
     std::cout << "\t\tTiramisu DenseNet block duration"

--- a/benchmarks/DNN/blocks/LSTM/cpu/configure.h
+++ b/benchmarks/DNN/blocks/LSTM/cpu/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_CONF_HEADER_
 #define __CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	0
 #define MEDIUM_DATA_SET	0
 #define SMALL_DATA_SET	1
@@ -34,7 +36,7 @@
 #define NB_TESTS 1
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -43,11 +45,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -79,5 +81,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/blocks/LSTM/cpu/lstm_block_generator_mkldnn.cpp
+++ b/benchmarks/DNN/blocks/LSTM/cpu/lstm_block_generator_mkldnn.cpp
@@ -91,14 +91,13 @@ void lstm()
                         user_wei_iter_memory, user_bias_memory,
                         dst_layer_memory, null_memory_, null_memory_));
 
-        std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+        std::vector<double> duration_vector;
         for (int i = 0; i < NB_TESTS; i++)
         {
-                auto start1 = std::chrono::high_resolution_clock::now();
+                double start = rtclock();
                 stream(stream::kind::eager).submit(lstm_net).wait();
-                auto end1 = std::chrono::high_resolution_clock::now();
-                std::chrono::duration<double, std::milli> duration = end1 - start1;
-                duration_vector.push_back(duration);
+                double end = rtclock();
+                duration_vector.push_back((end - start) * 1000);
         }
         std::cout << "\t\tMKL-DNN LSTM duration"
                   << ": " << median(duration_vector) << "; " << std::endl;

--- a/benchmarks/DNN/blocks/LSTM/cpu/wrapper.cpp
+++ b/benchmarks/DNN/blocks/LSTM/cpu/wrapper.cpp
@@ -12,8 +12,6 @@
 
 #include "wrapper.h"
 
-typedef std::chrono::duration<double,std::milli> duration_t;
-
 int main(int argc, char *argv[])
 {
     int warmupN = 0;
@@ -61,16 +59,17 @@ int main(int argc, char *argv[])
              buf_y.raw_buffer());
     }
 
-    std::vector<duration_t> durations;
+    std::vector<double> durations;
     for (int i = 0; i < NB_TESTS; i++) {
-        auto t1 = std::chrono::high_resolution_clock::now();
+        double t1 = rtclock();
         lstm(buf_params.raw_buffer(),
              buf_Weights.raw_buffer(),
              buf_biases.raw_buffer(),
              buf_x.raw_buffer(),
              buf_y.raw_buffer());
-        auto t2 = std::chrono::high_resolution_clock::now();
-        durations.push_back(t2 - t1);
+
+        double t2 = rtclock();
+        durations.push_back((t2 - t1) * 1000);
     }
 
     if (NB_TESTS > 0) {
@@ -104,7 +103,8 @@ int main(int argc, char *argv[])
         file_count += 1;
         f1 = std::stof(line1);
         f2 = std::stof(line2);
-        if (abs(f1 - f2) < 0.02)
+        
+        if (std::abs(f1 - f2) < 0.02)
             corr += 1;
     }
 

--- a/benchmarks/DNN/blocks/Resize-Conv/configure.h
+++ b/benchmarks/DNN/blocks/Resize-Conv/configure.h
@@ -1,6 +1,8 @@
 #ifndef __RESIZE_CONV_CONF_HEADER_
 #define __RESIZE_CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	0
 #define MEDIUM_DATA_SET	1
 #define SMALL_DATA_SET	0
@@ -41,7 +43,7 @@
 #define NB_TESTS 51
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -50,11 +52,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -86,5 +88,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/blocks/Resize-Conv/resize_conv_generator_mkl.cpp
+++ b/benchmarks/DNN/blocks/Resize-Conv/resize_conv_generator_mkl.cpp
@@ -50,7 +50,7 @@ int main()
 {
     srand(1);
 
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
     dnnError_t err;
 
     // Define some parameters
@@ -127,11 +127,8 @@ int main()
     CHECK_ERR(init_conversion(&cv_conv_to_usr_output, &output_buf, lt_user_output, lt_conv_output, res_conv[dnnResourceDst]), err);
 
     // Execute the block
-    double times[NB_TESTS];
-    clock_t start, end;
-
     for (int i = 0; i < NB_TESTS; ++i) {
-        auto start = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
 
         // Loop through batch dimension to process each image with OpenCV
         for (int j = 0; j < BATCH_SIZE; ++j) {
@@ -144,9 +141,8 @@ int main()
         CHECK_ERR(dnnConversionExecute_F32(cv_usr_to_conv_input, (void*)resized_buf, res_conv[dnnResourceSrc]), err);
         CHECK_ERR(dnnExecute_F32(conv_primitive, (void**)res_conv), err);
 
-        auto end = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end - start;
-        duration_vector.push_back(duration);
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
 
     std::cout << "\t\tResize-Conv block time: "

--- a/benchmarks/DNN/blocks/Resize-Conv/resize_conv_generator_mkldnn.cpp
+++ b/benchmarks/DNN/blocks/Resize-Conv/resize_conv_generator_mkldnn.cpp
@@ -17,7 +17,7 @@ using namespace mkldnn;
 void resize_conv_block()
 {
     srand(1);
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
 
     engine cpu_engine(engine::kind::cpu, 0);
     stream cpu_stream(cpu_engine);
@@ -141,7 +141,7 @@ void resize_conv_block()
 
     // Execute the network
     for (int i = 0; i < NB_TESTS; ++i) {
-        auto start = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
 
         // Loop through batch dimension to process each image with OpenCV
         for (int j = 0; j < BATCH_SIZE; ++j) {
@@ -159,9 +159,8 @@ void resize_conv_block()
 
         cpu_stream.wait();
 
-        auto end = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end - start;
-        duration_vector.push_back(duration);
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
 
     std::cout << "\n\n\tResize-Conv block time : " << median(duration_vector) << " ms." << std::endl;

--- a/benchmarks/DNN/blocks/Resize-Conv/wrapper_nn_block.cpp
+++ b/benchmarks/DNN/blocks/Resize-Conv/wrapper_nn_block.cpp
@@ -12,7 +12,7 @@ using namespace std;
 int main()
 {
     srand(1);
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
 
     Halide::Buffer<float> input(FIn, IMG_WIDTH, IMG_HEIGHT, BATCH_SIZE);
 
@@ -41,7 +41,7 @@ int main()
 
     // Execute Tiramisu code
     for (int i = 0; i < NB_TESTS; ++i) {
-        auto start = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         resize_conv_block(
             input.raw_buffer(), 
             conv_filter.raw_buffer(), 
@@ -49,9 +49,8 @@ int main()
             output.raw_buffer()
         );
         
-        auto end = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end - start;
-        duration_vector.push_back(duration);	
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);	
     }
 
     std::cout << "\t\tTiramisu Resize-Conv block duration"

--- a/benchmarks/DNN/blocks/conv2/configure.h
+++ b/benchmarks/DNN/blocks/conv2/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_CONF_HEADER_
 #define __CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	1
 #define MEDIUM_DATA_SET	0
 #define SMALL_DATA_SET	0
@@ -37,7 +39,7 @@
 #define NB_TESTS 1
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -46,11 +48,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -82,5 +84,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/blocks/conv2/s_score_sample_2.c
+++ b/benchmarks/DNN/blocks/conv2/s_score_sample_2.c
@@ -155,12 +155,12 @@ static dnnError_t simple_net(int want_groups_conv) {
     if (cv_user_to_conv2_bias) CHECK_ERR( dnnConversionExecute_F32(cv_user_to_conv2_bias, user_c2_b, resConv2[dnnResourceBias]), err );
 
 
-    clock_t start, end;
-    start = clock();
+    double start, end;
+    start = rtclock();
     CHECK_ERR( dnnExecute_F32(conv1, (void*)resConv1), err );
     CHECK_ERR( dnnExecute_F32(conv2, (void*)resConv2), err );
-    end = clock();
-    double time_taken = ((double) (end - start)/CLOCKS_PER_SEC)*1000;
+    end = rtclock();
+    double time_taken = (end - start)*1000;
     printf("Convolution time: %f.\n",  time_taken);
 
     if (cv_conv2_to_user_output) CHECK_ERR( dnnConversionExecute_F32(cv_conv2_to_user_output, resConv2[dnnResourceDst], user_c2_o), err );

--- a/benchmarks/DNN/blocks/conv2/wrapper_nn_2.cpp
+++ b/benchmarks/DNN/blocks/conv2/wrapper_nn_2.cpp
@@ -21,8 +21,8 @@ int main(int, char**)
     Halide::Buffer<float> conv2_tiramisu(N, N, FOut, BATCH_SIZE);
     Halide::Buffer<int> parameters(5);
 
-    std::vector<std::chrono::duration<double,std::milli>> duration_vector_1;
-    std::vector<std::chrono::duration<double,std::milli>> duration_vector_2;
+    std::vector<double> duration_vector_1;
+    std::vector<double> duration_vector_2;
 
     for (int y = 0; y < N+K; ++y)
         for (int x = 0; x < N+K; ++x)
@@ -52,11 +52,10 @@ int main(int, char**)
 
     for (int i=0; i<NB_TESTS; i++)
     {
-	    auto start1 = std::chrono::high_resolution_clock::now();
+	    double start1 = rtclock();
 	    conv_halide(input.raw_buffer(), filter.raw_buffer(), bias.raw_buffer(), filter2.raw_buffer(), bias2.raw_buffer(), conv2_halide.raw_buffer());
-	    auto end1 = std::chrono::high_resolution_clock::now();
-	    std::chrono::duration<double,std::milli> duration = end1 - start1;
-	    duration_vector_1.push_back(duration);
+	    double end1 = rtclock();
+	    duration_vector_1.push_back((end1 - start1) * 1000);
     }
 
     std::cout << "\t\tHalide conv2" << ": " << median(duration_vector_1) << "; " << std::endl;
@@ -84,11 +83,10 @@ int main(int, char**)
 
     for (int i=0; i<NB_TESTS; i++)
     {
-        auto start1 = std::chrono::high_resolution_clock::now();
-	conv_tiramisu(parameters.raw_buffer(), input.raw_buffer(), filter.raw_buffer(), bias.raw_buffer(), conv.raw_buffer(), filter2.raw_buffer(), bias2.raw_buffer(), conv2_tiramisu.raw_buffer());
-	auto end1 = std::chrono::high_resolution_clock::now();
-	std::chrono::duration<double,std::milli> duration = end1 - start1;
-	duration_vector_2.push_back(duration);
+        double start2 = rtclock();
+        conv_tiramisu(parameters.raw_buffer(), input.raw_buffer(), filter.raw_buffer(), bias.raw_buffer(), conv.raw_buffer(), filter2.raw_buffer(), bias2.raw_buffer(), conv2_tiramisu.raw_buffer());
+        double end2 = rtclock();
+        duration_vector_2.push_back((end2 - start2) * 1000);
     }
 
     std::cout << "\t\tTiramisu conv2" << ": " << median(duration_vector_2) << "; " << std::endl;

--- a/benchmarks/DNN/blocks/fusedresNet/configure.h
+++ b/benchmarks/DNN/blocks/fusedresNet/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_CONF_HEADER_
 #define __CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	0
 #define MEDIUM_DATA_SET	0
 #define SMALL_DATA_SET	1
@@ -50,7 +52,7 @@
 #define NB_TESTS 1
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -59,11 +61,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -95,5 +97,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/blocks/fusedresNet/fused_resnet_block_generator_mkl.c
+++ b/benchmarks/DNN/blocks/fusedresNet/fused_resnet_block_generator_mkl.c
@@ -184,10 +184,10 @@ int main()
     // Execute the block
     float* resources[dnnResourceNumber] = {0};
     double times[NB_TESTS];
-    clock_t start, end;
+    double start, end;
 
     for (int i = 0; i < NB_TESTS; ++i) {
-        start = clock();
+        start = rtclock();
         
         CHECK_ERR(dnnExecute_F32(conv1_primitive, (void**)res_conv1), err);
 
@@ -210,9 +210,8 @@ int main()
         resources[dnnResourceDst] = res_conv2[dnnResourceDst];
         CHECK_ERR(dnnExecute_F32(bn2_primitive, (void**)resources), err);
 
-        end = clock();
-        double time_taken = ((double)(end - start) / CLOCKS_PER_SEC) * 1000;
-        times[i] = time_taken;
+        end = rtclock();
+        times[i] = (end - start) * 1000;
     }
 
     printf("\n\n\tMKL ResNet block duration : %f ms.\n", median(NB_TESTS, times));

--- a/benchmarks/DNN/blocks/fusedresNet/fused_resnet_block_generator_mkldnn.cpp
+++ b/benchmarks/DNN/blocks/fusedresNet/fused_resnet_block_generator_mkldnn.cpp
@@ -280,17 +280,16 @@ void resnetBlock()
     net_fwd.push_back(conv2);
     net_fwd.push_back(bn2);
 
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector_2;
+    std::vector<double> duration_vector;
     for (int i = 0; i < NB_TESTS; i++)
     {
-        auto start1 = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         stream(stream::kind::eager).submit(net_fwd).wait();
-        auto end1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end1 - start1;
-        duration_vector_2.push_back(duration);
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
     std::cout << "\t\tMKL-DNN ResNet block duration "
-              << ": " << median(duration_vector_2) << "; " << std::endl;
+              << ": " << median(duration_vector) << "; " << std::endl;
 
     printf("writing result in file\n");
     ofstream resultfile;

--- a/benchmarks/DNN/blocks/fusedresNet/wrapper_nn_block.cpp
+++ b/benchmarks/DNN/blocks/fusedresNet/wrapper_nn_block.cpp
@@ -51,7 +51,8 @@ int main(int, char **)
     Halide::Buffer<double> mean(N, N, 64, BATCH_SIZE);
     Halide::Buffer<double> variance(N, N, 64, BATCH_SIZE);
 
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
+
     srand(1);
     for (int n = 0; n < BATCH_SIZE; ++n)
         for (int z = 0; z < 3; ++z)
@@ -79,14 +80,14 @@ int main(int, char **)
 
     for (int i = 0; i < NB_TESTS; i++)
     {
-        auto start1 = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         fused_resnet_block(parameters.raw_buffer(), filter1.raw_buffer(),
                            filter2.raw_buffer(), input.raw_buffer(), padd1.raw_buffer(),
                            conv1.raw_buffer(), mean.raw_buffer(), variance.raw_buffer(),
                            bn1.raw_buffer(), padd2.raw_buffer(), conv2.raw_buffer(), bn2.raw_buffer());
-        auto end1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end1 - start1;
-        duration_vector.push_back(duration);
+        
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
     std::cout << "\t\tTiramisu ResNet block duration "
               << ": " << median(duration_vector) << "; " << std::endl;

--- a/benchmarks/DNN/blocks/vggBlock/configure.h
+++ b/benchmarks/DNN/blocks/vggBlock/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_CONF_HEADER_
 #define __CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	0
 #define MEDIUM_DATA_SET	0
 #define SMALL_DATA_SET	1
@@ -14,7 +16,7 @@
 #endif
 
 // Width and height of an input tensor
-#define N 256
+#define N 56
 
 // Number of features in the input
 #define FIn 64
@@ -39,7 +41,7 @@
 #define NB_TESTS 51
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -48,11 +50,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -84,5 +86,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/blocks/vggBlock/vgg_block_generator_mkl.c
+++ b/benchmarks/DNN/blocks/vggBlock/vgg_block_generator_mkl.c
@@ -235,10 +235,10 @@ static dnnError_t simple_net(int want_groups_conv)
         CHECK_ERR(dnnConversionExecute_F32(cv_user_to_conv1_input, user_i, resConv1[dnnResourceSrc]), err);
     
     double times[NB_TESTS];
-    clock_t start, end;
+    double start, end;
 
     for (int i = 0; i < NB_TESTS; i++) {
-        start = clock();
+        start = rtclock();
 
         CHECK_ERR(dnnExecute_F32(conv1, (void *)resConv1), err);
         CHECK_ERR(dnnExecute_F32(relu1, (void *)resRelu1), err);
@@ -246,9 +246,8 @@ static dnnError_t simple_net(int want_groups_conv)
         CHECK_ERR(dnnExecute_F32(relu2, (void *)resRelu2), err);
         CHECK_ERR(dnnExecute_F32(pool1, (void *)resPool1), err);
 
-        end = clock();
-        double time_taken = ((double)(end - start) / CLOCKS_PER_SEC) * 1000;
-        times[i] = time_taken;
+        end = rtclock();
+        times[i] = (end - start) * 1000;
     }
     
     printf("\n\n\tVGG block time: %f ms.\n", median(NB_TESTS, times));

--- a/benchmarks/DNN/blocks/vggBlock/vgg_block_generator_mkldnn.cpp
+++ b/benchmarks/DNN/blocks/vggBlock/vgg_block_generator_mkldnn.cpp
@@ -14,7 +14,7 @@ using namespace std;
 void vggBlock()
 {
     srand(1);
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
 
     engine cpu_engine(engine::kind::cpu, 0);
     stream cpu_stream(cpu_engine);
@@ -256,16 +256,15 @@ void vggBlock()
 
     // Execute the network
     for (int i = 0; i < NB_TESTS; ++i) {
-        auto start = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         
         for (size_t j = 0; j < net.size(); ++j)
             net[j].execute(cpu_stream, net_args[j]);
 
         cpu_stream.wait();
 
-        auto end = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end - start;
-        duration_vector.push_back(duration);
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
 
     std::cout << "\n\n\tVGG block time : " << median(duration_vector) << " ms." << std::endl;

--- a/benchmarks/DNN/blocks/vggBlock/wrapper_nn_block.cpp
+++ b/benchmarks/DNN/blocks/vggBlock/wrapper_nn_block.cpp
@@ -24,7 +24,7 @@ int main(int, char **)
 
 	Halide::Buffer<float> output(FOUT_BLOCKING, N/2, N/2, FOUT_NB_BLOCKS, BATCH_SIZE);
 
-	std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+	std::vector<double> duration_vector;
 
 	// Initialize buffers
 	srand(1);
@@ -56,7 +56,7 @@ int main(int, char **)
 
 	// Execute Tiramisu code
 	for (int i = 0; i < NB_TESTS; i++) {
-		auto start1 = std::chrono::high_resolution_clock::now();
+		double start = rtclock();
 
 		vgg_block(
 			input.raw_buffer(), 
@@ -67,9 +67,8 @@ int main(int, char **)
 			output.raw_buffer()
 		);
 
-		auto end1 = std::chrono::high_resolution_clock::now();
-		std::chrono::duration<double, std::milli> duration = end1 - start1;
-		duration_vector.push_back(duration);
+		double end = rtclock();
+		duration_vector.push_back((end - start) * 1000);
 	}
 
 	std::cout << "\t\tTiramisu vgg Block duration"

--- a/benchmarks/DNN/layers/bn/cpu/bn_layer_generator_mkl.c
+++ b/benchmarks/DNN/layers/bn/cpu/bn_layer_generator_mkl.c
@@ -58,10 +58,10 @@ int main()
     // Execute the primitive
     float* resources[dnnResourceNumber] = {0};
     double times[NB_TESTS];
-    clock_t start, end;
+    double start, end;
 
     for (int i = 0; i < NB_TESTS; ++i) {
-        start = clock();
+        start = rtclock();
 
         resources[dnnResourceSrc] = input_buf;
         resources[dnnResourceScaleShift] = bn_scale_shift;
@@ -69,9 +69,8 @@ int main()
         resources[dnnResourceDst] = output_buf;
         CHECK_ERR(dnnExecute_F32(bn_primitive, (void**)resources), err);
 
-        end = clock();
-        double time_taken = ((double)(end - start) / CLOCKS_PER_SEC) * 1000;
-        times[i] = time_taken;
+        end = rtclock();
+        times[i] = (end - start) * 1000;
     }
 
     printf("\n\n\tMKL BN duration: %f ms.\n", median(NB_TESTS, times));

--- a/benchmarks/DNN/layers/bn/cpu/bn_layer_generator_mkldnn.cpp
+++ b/benchmarks/DNN/layers/bn/cpu/bn_layer_generator_mkldnn.cpp
@@ -14,8 +14,9 @@ using namespace std;
 
 void bn_mkldnn()
 {
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    std::vector<double> duration_vector;
     auto cpu_engine = engine(engine::cpu, 0);
+
     std::vector<float> net_src(BATCH_SIZE * FIn * N * N);
     std::vector<float> net_dst(BATCH_SIZE * FIn * N * N);
     std::vector<float> mean_vect(FIn);
@@ -77,11 +78,11 @@ void bn_mkldnn()
 
     for (int i = 0; i < NB_TESTS; i++)
     {
-        auto start1 = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         stream(stream::kind::eager).submit(net_fwd).wait();
-        auto end1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end1 - start1;
-        duration_vector.push_back(duration);
+
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
 
     std::cout << "\t\tMKL-DNN BN duration"

--- a/benchmarks/DNN/layers/bn/cpu/configure.h
+++ b/benchmarks/DNN/layers/bn/cpu/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_CONF_HEADER_
 #define __CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	0
 #define MEDIUM_DATA_SET	0
 #define SMALL_DATA_SET	1
@@ -40,7 +42,7 @@
 #define NB_TESTS 100
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -49,11 +51,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -85,5 +87,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/layers/bn/cpu/wrapper_nn.cpp
+++ b/benchmarks/DNN/layers/bn/cpu/wrapper_nn.cpp
@@ -21,8 +21,8 @@ int main(int, char **)
     Halide::Buffer<float> mean(N, N, FIn, BATCH_SIZE);
     Halide::Buffer<float> variance(N, N, FIn, BATCH_SIZE);
 
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector_1;
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector_2;
+    std::vector<double> duration_vector;
+
     srand(1);
     for (int n = 0; n < BATCH_SIZE; ++n)
         for (int z = 0; z < FIn; ++z)
@@ -37,14 +37,16 @@ int main(int, char **)
 
     for (int i = 0; i < NB_TESTS; i++)
     {
-        auto start1 = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         bn_tiramisu(input.raw_buffer(), parameters.raw_buffer(), mean.raw_buffer(), variance.raw_buffer(), output.raw_buffer());
-        auto end1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end1 - start1;
-        duration_vector_2.push_back(duration);
+        
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
+
     std::cout << "\t\tTiramisu BN duration"
-              << ": " << median(duration_vector_2) << "; " << std::endl;
+              << ": " << median(duration_vector) << "; " << std::endl;
+              
     std::ofstream resultfile;
     resultfile.open("tiramisu_result.txt");
     for (int n = 0; n < BATCH_SIZE; ++n)

--- a/benchmarks/DNN/layers/convolution/direct/cpu/configure.h
+++ b/benchmarks/DNN/layers/convolution/direct/cpu/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_CONF_HEADER_
 #define __CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define SPECIALIZE 1
 
 #define LARGE_DATA_SET	1
@@ -321,7 +323,7 @@ int fill_sizes_array(int sizes[NB_MAX_SIZES][4], int nb_sizes)
 }
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -330,11 +332,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -366,5 +368,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/layers/convolution/direct/cpu/conv_layer_wrapper.cpp
+++ b/benchmarks/DNN/layers/convolution/direct/cpu/conv_layer_wrapper.cpp
@@ -23,65 +23,64 @@ int main(int, char**)
         int C_FIn = sizes[j][2];
         int C_FOut = sizes[j][3];
 
-	Halide::Buffer<float> input(C_N+K, C_N+K, C_FIn, C_BATCH_SIZE);
-	Halide::Buffer<float> filter(K, K, C_FIn, C_FOut);
-	Halide::Buffer<float> bias(C_FIn);
-	Halide::Buffer<float> conv(C_N, C_N, C_FOut, C_BATCH_SIZE);
-	Halide::Buffer<float> conv_tiramisu_buffer(C_N, C_N, C_FOut, C_BATCH_SIZE);
-	Halide::Buffer<int> parameters(K);
+		Halide::Buffer<float> input(C_N+K, C_N+K, C_FIn, C_BATCH_SIZE);
+		Halide::Buffer<float> filter(K, K, C_FIn, C_FOut);
+		Halide::Buffer<float> bias(C_FIn);
+		Halide::Buffer<float> conv(C_N, C_N, C_FOut, C_BATCH_SIZE);
+		Halide::Buffer<float> conv_tiramisu_buffer(C_N, C_N, C_FOut, C_BATCH_SIZE);
+		Halide::Buffer<int> parameters(K);
 
-	std::vector<std::chrono::duration<double,std::milli>> duration_vector_1;
-	std::vector<std::chrono::duration<double,std::milli>> duration_vector_2;
+		std::vector<double> duration_vector;
 
-	for (int y = 0; y < C_N+K; ++y)
-	    for (int x = 0; x < C_N+K; ++x)
+		for (int y = 0; y < C_N+K; ++y)
+			for (int x = 0; x < C_N+K; ++x)
+			for (int z = 0; z < C_FIn; ++z)
+				for (int n = 0; n < C_BATCH_SIZE; ++n)
+				input(x, y, z, n) = 1;
+
 		for (int z = 0; z < C_FIn; ++z)
-		    for (int n = 0; n < C_BATCH_SIZE; ++n)
-			input(x, y, z, n) = 1;
+			bias(z) = 1;
 
-	for (int z = 0; z < C_FIn; ++z)
-	    bias(z) = 1;
+		for (int y = 0; y < K; ++y)
+			for (int x = 0; x < K; ++x)
+			for (int z = 0; z < C_FIn; ++z)
+				for (int q = 0; q < C_FOut; ++q)
+				filter(x, y, z, q) = 1;
 
-	 for (int y = 0; y < K; ++y)
-	    for (int x = 0; x < K; ++x)
-		for (int z = 0; z < C_FIn; ++z)
-		    for (int q = 0; q < C_FOut; ++q)
-			filter(x, y, z, q) = 1;
+		std::cout << "\t\tBuffers initialized" << std::endl;
 
-	std::cout << "\t\tBuffers initialized" << std::endl;
+		unsigned int count = 0;
 
-	unsigned int count = 0;
+		// Initialize parameters[]
+		parameters(0) = C_N;
+		parameters(1) = K;
+		parameters(2) = C_FIn;
+		parameters(3) = C_FOut;
+		parameters(4) = C_BATCH_SIZE;
 
-	// Initialize parameters[]
-	parameters(0) = C_N;
-	parameters(1) = K;
-	parameters(2) = C_FIn;
-	parameters(3) = C_FOut;
-	parameters(4) = C_BATCH_SIZE;
+		for (int i=0; i<NB_TESTS; i++)
+		{
+			double start = rtclock();
+			conv_tiramisu(parameters.raw_buffer(), input.raw_buffer(), filter.raw_buffer(), bias.raw_buffer(), conv_tiramisu_buffer.raw_buffer());
+			
+			double end = rtclock();
+			duration_vector.push_back((end - start) * 1000);
+		}
 
-	for (int i=0; i<NB_TESTS; i++)
-	{
-	    auto start1 = std::chrono::high_resolution_clock::now();
-	    conv_tiramisu(parameters.raw_buffer(), input.raw_buffer(), filter.raw_buffer(), bias.raw_buffer(), conv_tiramisu_buffer.raw_buffer());
-	    auto end1 = std::chrono::high_resolution_clock::now();
-	    std::chrono::duration<double,std::milli> duration = end1 - start1;
-	    duration_vector_2.push_back(duration);
-	}
-
-	std::cout << "\t\tN = " << C_N << "; BATCH_SIZE = " << C_BATCH_SIZE << "; FIn = " << C_FIn << "; FOut = " << C_FOut << ";" << std::endl;
-	std::cout << "\t\tTiramisu conv" << ": " << median(duration_vector_2) << "; " << std::endl;
-	std::cout << "\t\tResult" << ": ";
-	count = 0;
-	for (int y = 0; y < C_N+K; ++y)
-	    for (int x = 0; x < C_N+K; ++x)
-		for (int z = 0; z < C_FIn; ++z)
-		    for (int n = 0; n < C_BATCH_SIZE; ++n)
-			if (count < 10)
-			{
-			    std::cerr << conv_tiramisu_buffer(x, y, z, n) << ", ";
-			    count++;
-			}
-	std::cout << std::endl;
+		std::cout << "\t\tN = " << C_N << "; BATCH_SIZE = " << C_BATCH_SIZE << "; FIn = " << C_FIn << "; FOut = " << C_FOut << ";" << std::endl;
+		std::cout << "\t\tTiramisu conv" << ": " << median(duration_vector) << "; " << std::endl;
+		std::cout << "\t\tResult" << ": ";
+		count = 0;
+		for (int y = 0; y < C_N+K; ++y)
+			for (int x = 0; x < C_N+K; ++x)
+			for (int z = 0; z < C_FIn; ++z)
+				for (int n = 0; n < C_BATCH_SIZE; ++n)
+				if (count < 10)
+				{
+					std::cerr << conv_tiramisu_buffer(x, y, z, n) << ", ";
+					count++;
+				}
+		std::cout << std::endl;
     }
 
     return 0;

--- a/benchmarks/DNN/layers/convolution/direct/cpu/s_score_sample.c
+++ b/benchmarks/DNN/layers/convolution/direct/cpu/s_score_sample.c
@@ -149,14 +149,14 @@ static dnnError_t simple_net(int want_groups_conv)
             CHECK_ERR(dnnConversionExecute_F32(cv_user_to_conv1_input, user_i, resConv1[dnnResourceSrc]), err);
 
         double times[NB_TESTS];
-        clock_t start, end;
+        double start, end;
         for (int i = 0; i < NB_TESTS; i++)
         {
-            start = clock();
+            start = rtclock();
             CHECK_ERR(dnnExecute_F32(conv1, (void *)resConv1), err);
-            end = clock();
-            double time_taken = ((double)(end - start) / CLOCKS_PER_SEC) * 1000;
-            times[i] = time_taken;
+            
+            end = rtclock();
+            times[i] = (end - start) * 1000;
         }
         printf("Convolution time: %f.\n", median(NB_TESTS, times));
         fprintf(f, "%f\n", median(NB_TESTS, times));

--- a/benchmarks/DNN/layers/maxpool/cpu/configure.h
+++ b/benchmarks/DNN/layers/maxpool/cpu/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_CONF_HEADER_
 #define __CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	0	
 #define MEDIUM_DATA_SET	1
 #define SMALL_DATA_SET	0
@@ -45,7 +47,7 @@
 #define NB_TESTS 1
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -54,11 +56,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -90,5 +92,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/layers/maxpool/cpu/maxpool_layer_generator_mkl.c
+++ b/benchmarks/DNN/layers/maxpool/cpu/maxpool_layer_generator_mkl.c
@@ -123,14 +123,14 @@ static dnnError_t simple_net(int want_groups_conv)
         CHECK_ERR(dnnConversionExecute_F64(cv_user_to_pool1_input, user_i, resPool1[dnnResourceSrc]), err);
 
     double times[NB_TESTS];
-    clock_t start, end;
+    double start, end;
     for (int i = 0; i < NB_TESTS; i++)
     {
-        start = clock();
+        start = rtclock();
         CHECK_ERR(dnnExecute_F64(pool1, (void *)resPool1), err);
-        end = clock();
-        double time_taken = ((double)(end - start) / CLOCKS_PER_SEC) * 1000;
-        times[i] = time_taken;
+
+        end = rtclock();
+        times[i] = (end - start) * 1000;
     }
     printf("Pool time: %f.\n", median(NB_TESTS, times));
 

--- a/benchmarks/DNN/layers/maxpool/cpu/maxpool_layer_generator_mkldnn.cpp
+++ b/benchmarks/DNN/layers/maxpool/cpu/maxpool_layer_generator_mkldnn.cpp
@@ -82,17 +82,17 @@ void maxpool()
     if (reorder_pool_dst)
         net_fwd.push_back(pool_reorder_dst);
 
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector_2;
+    std::vector<double> duration_vector;
     for (int i = 0; i < NB_TESTS; i++)
     {
-        auto start1 = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         stream(stream::kind::eager).submit(net_fwd).wait();
-        auto end1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end1 - start1;
-        duration_vector_2.push_back(duration);
+
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
     std::cout << "\t\tMKL-DNN maxpool duration"
-              << ": " << median(duration_vector_2) << "; " << std::endl;
+              << ": " << median(duration_vector) << "; " << std::endl;
 
     printf("writing result in file\n");
     ofstream resultfile;

--- a/benchmarks/DNN/layers/maxpool/cpu/wrapper_nn_maxpool.cpp
+++ b/benchmarks/DNN/layers/maxpool/cpu/wrapper_nn_maxpool.cpp
@@ -51,8 +51,7 @@ int main(int, char **)
     Halide::Buffer<float> inputPadd(N + 2 * P_X, N + 2 * P_Y, FIn, BATCH_SIZE);
     Halide::Buffer<float> output((N - K_X + 2 * P_X) / S_X + 1, (N - K_Y + 2 * P_Y) / S_Y + 1, FIn, BATCH_SIZE);
 
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector_1;
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector_2;
+    std::vector<double> duration_vector;
 
     srand(1);
     for (int n = 0; n < BATCH_SIZE; ++n)
@@ -68,15 +67,16 @@ int main(int, char **)
 
     for (int i = 0; i < NB_TESTS; i++)
     {
-        auto start1 = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         maxpool_tiramisu(parameters.raw_buffer(), input.raw_buffer(), output.raw_buffer(),
                          strides.raw_buffer(), padding.raw_buffer(), kernel.raw_buffer(), inputPadd.raw_buffer());
-        auto end1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end1 - start1;
-        duration_vector_2.push_back(duration);
+        
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
+
     std::cout << "\t\tTiramisu maxpool duration"
-              << ": " << median(duration_vector_2) << "; " << std::endl;
+              << ": " << median(duration_vector) << "; " << std::endl;
 
     std::ofstream resultfile;
     resultfile.open("tiramisu_result.txt");

--- a/benchmarks/DNN/layers/relu/cpu/configure.h
+++ b/benchmarks/DNN/layers/relu/cpu/configure.h
@@ -1,6 +1,8 @@
 #ifndef __CONV_CONF_HEADER_
 #define __CONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 #define LARGE_DATA_SET	0
 #define MEDIUM_DATA_SET	1
 #define SMALL_DATA_SET	0
@@ -40,7 +42,7 @@
 #define NB_TESTS 100
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -49,11 +51,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -85,5 +87,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/layers/relu/cpu/relu_layer_generator_mkl.c
+++ b/benchmarks/DNN/layers/relu/cpu/relu_layer_generator_mkl.c
@@ -96,14 +96,14 @@ static dnnError_t simple_net()
         CHECK_ERR(dnnConversionExecute_F64(cv_user_to_relu1_input, user_i, resRelu1[dnnResourceSrc]), err);
 
     double times[NB_TESTS];
-    clock_t start, end;
+    double start, end;
     for (int i = 0; i < NB_TESTS; i++)
     {
-        start = clock();
+        start = rtclock();
         CHECK_ERR(dnnExecute_F64(relu1, (void *)resRelu1), err);
-        end = clock();
-        double time_taken = ((double)(end - start) / CLOCKS_PER_SEC) * 1000;
-        times[i] = time_taken;
+        
+        end = rtclock();
+        times[i] = (end - start) * 1000;
     }
     printf("Relu time: %f.\n", median(NB_TESTS, times));
 

--- a/benchmarks/DNN/layers/relu/cpu/relu_layer_generator_mkldnn.cpp
+++ b/benchmarks/DNN/layers/relu/cpu/relu_layer_generator_mkldnn.cpp
@@ -51,17 +51,17 @@ void relu()
     std::vector<primitive> net_fwd;
     net_fwd.push_back(relu);
 
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector_2;
+    std::vector<double> duration_vector;
     for (int i = 0; i < NB_TESTS; i++)
     {
-        auto start1 = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         stream(stream::kind::eager).submit(net_fwd).wait();
-        auto end1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end1 - start1;
-        duration_vector_2.push_back(duration);
+
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
     std::cout << "\t\tMKL-DNN relu duration"
-              << ": " << median(duration_vector_2) << "; " << std::endl;
+              << ": " << median(duration_vector) << "; " << std::endl;
 
     ofstream resultfile;
     resultfile.open("mkldnn_result.txt");

--- a/benchmarks/DNN/layers/relu/cpu/wrapper_nn_relu.cpp
+++ b/benchmarks/DNN/layers/relu/cpu/wrapper_nn_relu.cpp
@@ -14,8 +14,7 @@ int main(int, char **)
     Halide::Buffer<float> input(N, N, FIn, BATCH_SIZE);
     Halide::Buffer<float> output(N, N, FIn, BATCH_SIZE);
     Halide::Buffer<float> parameters(4);
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector_1;
-    std::vector<std::chrono::duration<double, std::milli>> duration_vector_2;
+    std::vector<double> duration_vector;
 
     srand(1);
     for (int n = 0; n < BATCH_SIZE; ++n)
@@ -32,14 +31,14 @@ int main(int, char **)
 
     for (int i = 0; i < NB_TESTS; i++)
     {
-        auto start1 = std::chrono::high_resolution_clock::now();
+        double start = rtclock();
         relu_tiramisu(input.raw_buffer(), parameters.raw_buffer(), output.raw_buffer());
-        auto end1 = std::chrono::high_resolution_clock::now();
-        std::chrono::duration<double, std::milli> duration = end1 - start1;
-        duration_vector_2.push_back(duration);
+
+        double end = rtclock();
+        duration_vector.push_back((end - start) * 1000);
     }
     std::cout << "\t\tTiramisu relu duration"
-              << ": " << median(duration_vector_2) << "; " << std::endl;
+              << ": " << median(duration_vector) << "; " << std::endl;
 
     std::ofstream resultfile;
     resultfile.open("tiramisu_result.txt");

--- a/benchmarks/DNN/layers/transpose_conv/configure.h
+++ b/benchmarks/DNN/layers/transpose_conv/configure.h
@@ -1,6 +1,8 @@
 #ifndef __DECONV_CONF_HEADER_
 #define __DECONV_CONF_HEADER_
 
+#include <sys/time.h>
+
 // Print the output
 #define SHOW_OUTPUT 0
 // Save to file and compare mkldnn to tiramisu
@@ -41,7 +43,7 @@
 #define NB_TESTS 100
 
 #ifdef __cplusplus
-double median(std::vector<std::chrono::duration<double, std::milli>> scores)
+double median(std::vector<double> scores)
 {
     double median;
     size_t size = scores.size();
@@ -50,11 +52,11 @@ double median(std::vector<std::chrono::duration<double, std::milli>> scores)
 
     if (size % 2 == 0)
     {
-        median = (scores[size / 2 - 1].count() + scores[size / 2].count()) / 2;
+        median = (scores[size / 2 - 1] + scores[size / 2]) / 2;
     }
     else
     {
-        median = scores[size / 2].count();
+        median = scores[size / 2];
     }
 
     return median;
@@ -86,5 +88,13 @@ double median(int n, double x[])
     }
 }
 #endif
+
+double rtclock()
+{
+    struct timeval Tp;
+    gettimeofday(&Tp, NULL);
+
+    return (Tp.tv_sec + Tp.tv_usec * 1.0e-6);
+}
 
 #endif

--- a/benchmarks/DNN/layers/transpose_conv/transpose_conv_generator_mkldnn.cpp
+++ b/benchmarks/DNN/layers/transpose_conv/transpose_conv_generator_mkldnn.cpp
@@ -14,7 +14,7 @@ using namespace mkldnn;
 void transpose_conv()
 {
     	int OUTPUT_N = ((N-1)*STRIDE + K - 2 * PADDING);
-    	std::vector<std::chrono::duration<double, std::milli>> duration_vector;
+    	std::vector<double> duration_vector;
 	
     	engine cpu_engine(engine::kind::cpu, 0);
     	stream cpu_stream(cpu_engine);
@@ -135,15 +135,14 @@ void transpose_conv()
 	
     	// Execute the deconvolution
 	for (int i = 0; i < NB_TESTS; ++i) {
-		auto start = std::chrono::high_resolution_clock::now();
+		double start = rtclock();
 
 		deconv.execute(cpu_stream, deconv_args);
 
 		cpu_stream.wait();
 
-		auto end = std::chrono::high_resolution_clock::now();
-		std::chrono::duration<double, std::milli> duration = end - start;
-		duration_vector.push_back(duration);
+		double end = rtclock();
+		duration_vector.push_back((end - start) * 1000);
 	}
 	
     	std::cout << "\n\n\tMKLDNN Deconv time : " << median(duration_vector) << " ms." << std::endl;

--- a/benchmarks/DNN/layers/transpose_conv/transpose_conv_wrapper_tiramisu.cpp
+++ b/benchmarks/DNN/layers/transpose_conv/transpose_conv_wrapper_tiramisu.cpp
@@ -16,8 +16,7 @@ int main(int, char**)
     	Halide::Buffer<float> result(OUTPUT_N, OUTPUT_N, FOut, BATCH_SIZE);
 	init_buffer(result, (float) 0);
 	
-    	std::vector<std::chrono::duration<double,std::milli>> duration_vector_1;
-    	std::vector<std::chrono::duration<double,std::milli>> duration_vector_2;
+    	std::vector<double> duration_vector;
 	
     	for (int n=0; n < BATCH_SIZE; n++)
 		for (int z=0; z < FIn; z++)
@@ -38,14 +37,14 @@ int main(int, char**)
 	
     	for (int i=0; i < NB_TESTS; i++)
     	{
-		auto start1 = std::chrono::high_resolution_clock::now();
+		double start = rtclock();
 		transpose_conv(input.raw_buffer(), filter.raw_buffer(), bias.raw_buffer(), result.raw_buffer());
-		auto end1 = std::chrono::high_resolution_clock::now();
-		std::chrono::duration<double,std::milli> duration = end1 - start1;
-		duration_vector_2.push_back(duration);
+		
+		double end = rtclock();
+		duration_vector.push_back((end - start) * 1000);
 	}
 	
-    	std::cout << "\t\tTiramisu Deconv time : " << median(duration_vector_2) << "; " << std::endl;
+    	std::cout << "\t\tTiramisu Deconv time : " << median(duration_vector) << "; " << std::endl;
 	
 	// Print the output
     	if(SHOW_OUTPUT)


### PR DESCRIPTION
I put rtclock in configure.h because benchmarks.h defines some parameters like N and BATCH_SIZE, so I can't include both configure.h and benchmarks.h in a source file.

I used rtclock in all DNN benchmarks, except for GPU version of LSTM.