### PR TITLE
Update DNN benchmarks

### DIFF
--- a/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/configure.h
+++ b/benchmarks/DNN/blocks/Conv-ReLU-MaxPool/configure.h
@@ -21,7 +21,7 @@
 // Number of features in the input
 #define FIn 3
 // Number of features in the output
-#define FOut 64
+#define FOut 32
 
 // Size of convolution filter (K_YxK_X)
 #define K_X 3

--- a/benchmarks/DNN/blocks/Resize-Conv/configure.h
+++ b/benchmarks/DNN/blocks/Resize-Conv/configure.h
@@ -40,7 +40,7 @@
 
 #if N >= 224
     #define X_BLOCKING 8
-    #define Y_BLOCKING 2
+    #define Y_BLOCKING 4
     #define SCHEDULE_PREFETCH_WEIGHTS true
 #else
     #define X_BLOCKING 4

--- a/benchmarks/DNN/blocks/Resize-Conv/configure.h
+++ b/benchmarks/DNN/blocks/Resize-Conv/configure.h
@@ -25,7 +25,7 @@
 // Number of features in the input
 #define FIn 3
 // Number of features in the output
-#define FOut 64
+#define FOut 32
 
 // Size of convolution filter (K_YxK_X)
 #define K_X 3
@@ -54,7 +54,7 @@
 // If this is defined, print 10 array elements only
 #define PRINT_ONLY_10 0
 
-#define NB_TESTS 51
+#define NB_TESTS 101
 
 #ifdef __cplusplus
 double median(std::vector<double> scores)

--- a/benchmarks/DNN/blocks/vggBlock/configure.h
+++ b/benchmarks/DNN/blocks/vggBlock/configure.h
@@ -16,18 +16,17 @@
 #endif
 
 // Width and height of an input tensor
-#define N 56
+#define N 112
 
 // Number of features in the input
-#define FIn 64
+#define FIn 3
 // Number of features in the output
-#define FOut 128
+#define FOut 32
 
 // Size of convolution filter (KxK)
 #define K 3
 
 // Parameters for Tiramisu code
-#define FIN1_BLOCKING 8
 #define FIN2_BLOCKING 8
 #define FOUT_BLOCKING 8
 
@@ -35,10 +34,23 @@
 #define FIN2_NB_BLOCKS FOut/FIN2_BLOCKING
 #define FOUT_NB_BLOCKS FOut/FOUT_BLOCKING
 
+#if N >= 224
+    #define X_BLOCKING 8
+    #define Y_BLOCKING 2
+    #define SCHEDULE_PREFETCH_WEIGHTS true
+#else
+    #define X_BLOCKING 4
+    #define Y_BLOCKING 1
+    #define SCHEDULE_PREFETCH_WEIGHTS false
+#endif
+
+#define X_NB_BLOCKS N/X_BLOCKING
+#define Y_NB_BLOCKS N/Y_BLOCKING
+
 // If this is defined, print 10 array elements only
 #define PRINT_ONLY_10 1
 
-#define NB_TESTS 51
+#define NB_TESTS 101
 
 #ifdef __cplusplus
 double median(std::vector<double> scores)

--- a/benchmarks/DNN/blocks/vggBlock/vgg_block_generator_mkldnn.cpp
+++ b/benchmarks/DNN/blocks/vggBlock/vgg_block_generator_mkldnn.cpp
@@ -24,13 +24,14 @@ void vggBlock()
 
     // Initialize user buffers
     memory::dims conv_strides = {1, 1};
-    memory::dims conv_padding = {1, 1};
+    memory::dims conv1_padding = {0, 0};
+    memory::dims conv2_padding = {1, 1};
 
     memory::dims pool_strides = {2, 2};
     memory::dims pool_kernel = {2, 2};
     memory::dims pool_padding = {0, 0};
 
-    std::vector<float> input_buf(BATCH_SIZE*FIn*N*N);
+    std::vector<float> input_buf(BATCH_SIZE*FIn*(N + 2)*(N + 2));
 
     std::vector<float> conv1_bias_buf(FOut);
     std::vector<float> conv1_weights_buf(FOut*FIn*K*K);
@@ -38,7 +39,7 @@ void vggBlock()
     std::vector<float> conv2_bias_buf(FOut);
     std::vector<float> conv2_weights_buf(FOut*FOut*K*K);
 
-    for (int i = 0; i < BATCH_SIZE*FIn*N*N; i++)
+    for (int i = 0; i < BATCH_SIZE*FIn*(N + 2)*(N + 2); i++)
         input_buf[i] = (rand() % 200 - 100) / 100.;
 
     for (int i = 0; i < FOut; i++)
@@ -53,7 +54,7 @@ void vggBlock()
 
     // Create memory objects with user data format
     auto input_usr_md = memory::desc(
-        {BATCH_SIZE, FIn, N, N},
+        {BATCH_SIZE, FIn, N + 2, N + 2},
         memory::data_type::f32,
         memory::format_tag::nchw
     );
@@ -75,7 +76,7 @@ void vggBlock()
 
     // Create memory objects with a data format selected by the convolution primitive
     auto conv1_src_md = memory::desc(
-        {BATCH_SIZE, FIn, N, N},
+        {BATCH_SIZE, FIn, N + 2, N + 2},
         memory::data_type::f32,
         memory::format_tag::any
     );
@@ -108,8 +109,8 @@ void vggBlock()
         conv1_bias_md,
         output1_md,
         conv_strides,
-        conv_padding,
-        conv_padding
+        conv1_padding,
+        conv1_padding
     );
 
     post_ops conv1_post_ops;
@@ -194,8 +195,8 @@ void vggBlock()
         conv2_bias_md,
         output2_md,
         conv_strides,
-        conv_padding,
-        conv_padding
+        conv2_padding,
+        conv2_padding
     );
 
     auto conv2_pd = convolution_forward::primitive_desc(

--- a/benchmarks/DNN/layers/convolution/direct/cpu_bis/configure.h
+++ b/benchmarks/DNN/layers/convolution/direct/cpu_bis/configure.h
@@ -21,7 +21,7 @@
 // Number of features in the input
 #define FIn 3
 // Number of features in the output
-#define FOut 64
+#define FOut 32
 
 // Size of convolution filter (KxK)
 #define K 3


### PR DESCRIPTION
- In Resize-Conv, avoid changing the data layout of the input as this is not necessary in this case and this adds an overhead to execution time.
- Fuse Resize with Conv.
- Switch Conv-ReLU-MaxPool, Resize-Conv and Convolution to 32 output channels.
- Optimize vggBlock for 3 input channels.