### PR TITLE
Update CMake requirement to prevent config error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(tiramisu)
 
 enable_testing()


### PR DESCRIPTION
Since old CMake version can't find cuBLAS library successfully when GPU is enabled.
Update the CMake version requirement to alert user.

Reference: https://github.com/marian-nmt/marian/issues/261

![bug](https://user-images.githubusercontent.com/11689182/70994391-12ad7000-2109-11ea-8747-7861e9c0c743.png)
