### PR TITLE
added default virtual destructor to 'computation' and missing return …

### DIFF
--- a/include/tiramisu/core.h
+++ b/include/tiramisu/core.h
@@ -4380,6 +4380,8 @@ public:
 
     static xfer create_xfer(std::string iter_domain, xfer_prop prop, tiramisu::expr expr,
                             tiramisu::function *fct);
+
+    virtual ~computation() {}
 };
 
 class input: public computation

--- a/src/tiramisu_auto_scheduler.cpp
+++ b/src/tiramisu_auto_scheduler.cpp
@@ -25,7 +25,8 @@ namespace tiramisu
 
     computation_graph auto_scheduler::create_initial_computation_graph(function *fct)
     {
-
+        computation_graph g{};
+        return std::move(g);
     }
 
     void auto_scheduler::parallelism_apply(block &b)


### PR DESCRIPTION
clang-8 identifies two compile time issues. the first is a missing virtual dtor in `computation`, the second is a missing return value in `auto_scheduler::create_initial_computation_graph`.