### PR TITLE
code generation patch

### DIFF
--- a/src/tiramisu_codegen_halide.cpp
+++ b/src/tiramisu_codegen_halide.cpp
@@ -1508,11 +1508,51 @@ Halide::Expr halide_expr_from_isl_ast_expr_temp(isl_ast_expr *isl_expr)
                                 0);
                 break;
             case isl_ast_op_max:
-                result = Halide::Internal::Max::make2(op0, op1, true);
+
+                /**
+                 * min & max dont only have 2 operands, they have as two or more, as stated in isl documentation :
+                 * "isl_ast_op_max Maximum of two or more arguments."
+                */
+                {
+                    int nb = isl_ast_expr_get_op_n_arg(isl_expr);
+
+                    result = op0;
+
+                    for(int i=1;i<nb;i++)
+                    {
+                        isl_ast_expr *expr_itr = isl_ast_expr_get_op_arg(isl_expr, i);
+                        Halide::Expr current_op = halide_expr_from_isl_ast_expr_temp<T, N>(expr_itr);
+
+                        result = Halide::Internal::Max::make2(result, current_op, true);
+                        
+                        isl_ast_expr_free(expr_itr);
+
+                    }
+
+                    break;
+                }
+
+
                 break;
             case isl_ast_op_min:
-                result = Halide::Internal::Min::make2(op0, op1, true);
-                break;
+                {
+                    int nb = isl_ast_expr_get_op_n_arg(isl_expr);
+
+                    result = op0;
+
+                    for(int i=1;i<nb;i++)
+                    {
+                        isl_ast_expr *expr_itr = isl_ast_expr_get_op_arg(isl_expr, i);
+                        Halide::Expr current_op = halide_expr_from_isl_ast_expr_temp<T, N>(expr_itr);
+
+                        result = Halide::Internal::Min::make2(result, current_op, true);
+                        
+                        isl_ast_expr_free(expr_itr);
+
+                    }
+
+                    break;
+                }
             case isl_ast_op_minus:
                 result = Halide::Internal::Sub::make(Halide::cast(op0.type(), Halide::Expr(0)), op0, true);
                 break;


### PR DESCRIPTION
Our previous problem was tiling + skewing that causes segmentation error.
After deep investigation, the cause was an index out of bound error.
I compared ast from isl with halide IR, then I noticed that number of Min & Max in the code were missing.
the original code was limited to 2 min & max operands, this should not be the case.
As stated in isl documentation, min & max have 2 operands or MORE ...
this patch allows correct code generation and could solve many other issues that the cause was unknown.