### PR TITLE
add new fast installation method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ set(CMAKE_VERBOSE_MAKEFILE "ON")
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 include(configure.cmake)
 if (DEBUG_LEVEL GREATER_EQUAL 1)
-   set(ENABLE_DEBUG TRUE)
+    set(ENABLE_DEBUG TRUE)
 else()
-   set(ENABLE_DEBUG FALSE)
+    set(ENABLE_DEBUG FALSE)
 endif()
 
 
@@ -20,7 +20,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(PROJECT_BUILD ${CMAKE_BINARY_DIR})
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
 
-### FIND EXTERNAL DEPS ###
+# # # FIND EXTERNAL DEPS # # #
 if (${USE_GPU})
     find_package(CUDA REQUIRED)
     add_definitions(-DNVCC_PATH="${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc")
@@ -81,8 +81,29 @@ set(CMAKE_CXX_STANDARD 17)  # or newer
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-find_package(Halide REQUIRED)
-find_library(ISLLib isl PATHS ${ISL_LIB_DIRECTORY} NO_DEFAULT_PATH)
+
+# Option to set BIN_HALIDE_INSTALL_METHOD (default is 0)
+set(BIN_HALIDE_INSTALL_METHOD 0 CACHE STRING "Halide install method (0: Default, 1: Static)")
+
+# Condition based on BIN_HALIDE_INSTALL_METHOD value
+if(${BIN_HALIDE_INSTALL_METHOD} EQUAL 1)
+    message(STATUS "Using prebuilt Halide and ISL install method")
+
+    find_package(ZLIB REQUIRED)
+    find_package(Halide REQUIRED static)
+    find_library(ISLLib isl)
+
+elseif(${BIN_HALIDE_INSTALL_METHOD} EQUAL 0)
+    # If BIN_HALIDE_INSTALL_METHOD is 0
+    message(STATUS "Using default Halide and ISL install method (manually compiled)")
+
+    find_package(Halide REQUIRED)
+    find_library(ISLLib isl PATHS ${ISL_LIB_DIRECTORY} NO_DEFAULT_PATH)
+else()
+    # Handle unsupported values of BIN_HALIDE_INSTALL_METHOD
+    message(FATAL_ERROR "Invalid value for BIN_HALIDE_INSTALL_METHOD: ${BIN_HALIDE_INSTALL_METHOD}. Must be 0 or 1.")
+endif()
+
 
 if (${USE_MPI})
     set(CMAKE_CXX_COMPILER "${MPI_BUILD_DIR}/bin/mpicxx")
@@ -108,17 +129,21 @@ set(THREADS_PREFER_PTHREAD_FLAG YES)
 find_package(Threads REQUIRED)
 
 
-### Create targets ###
+# # # Create targets # # #
 
 add_subdirectory(src)
 
 if (WITH_PYTHON_BINDINGS)
-  message(STATUS "Building Python bindings enabled")
-  add_subdirectory(python_bindings)
-  target_include_directories(Tiramisu_Python PRIVATE "include")
+    message(STATUS "Building Python bindings enabled")
+    add_subdirectory(python_bindings)
+    # #
+    set_target_properties(Tiramisu_Python PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+  )
+    # target_include_directories(Tiramisu_Python PRIVATE "include")
 endif()
 
-## SETUP INSTALLS:
+# # SETUP INSTALLS:
 
 install(TARGETS tiramisu
 EXPORT tiramisu_Targets
@@ -128,7 +153,7 @@ PUBLIC_HEADER DESTINATION include/tiramisu
 )
 
 if (USE_AUTO_SCHEDULER)
-   install(TARGETS tiramisu_auto_scheduler
+    install(TARGETS tiramisu_auto_scheduler
    EXPORT tiramisu_Targets
    LIBRARY DESTINATION lib
    INCLUDES DESTINATION include
@@ -137,16 +162,16 @@ endif()
 
 
 if (WITH_PYTHON_BINDINGS)
-  install(FILES ${CMAKE_SOURCE_DIR}/python_bindings/tiramisu.pyi ${CMAKE_SOURCE_DIR}/python_bindings/__init__.py
+    install(FILES ${CMAKE_SOURCE_DIR}/python_bindings/tiramisu.pyi ${CMAKE_SOURCE_DIR}/python_bindings/__init__.py
   DESTINATION "${Tiramisu_INSTALL_PYTHONDIR}/tiramisu")
-  install(TARGETS Tiramisu_Python
+    install(TARGETS Tiramisu_Python
   EXPORT tiramisu_Targets
   LIBRARY DESTINATION "${Tiramisu_INSTALL_PYTHONDIR}/tiramisu")
 endif()
 
 
 
-### BROKEN: SETUP TESTS/BENCHMARKS/ETC ###
+# # # BROKEN: SETUP TESTS/BENCHMARKS/ETC # # #
 
 FILE(STRINGS tests/test_list.txt TIRAMISU_TESTS_RAW)
 FILE(STRINGS benchmarks/benchmark_list.txt TIRAMISU_BENCHMARKS_RAW)
@@ -189,12 +214,12 @@ function (parse_list raw_list list_name)
         else()
             list(APPEND tmp_result "false")
         endif()
-	# Check if we need to use CUDNN
+        # Check if we need to use CUDNN
         if(${is_cudnn})
-	    if(${USE_CUDNN})
+            if(${USE_CUDNN})
                 list(APPEND tmp_result "true")
             else()
-		    message(STATUS "skipping cudnn tagged ${name} because USE_CUDNN is not set to true")
+                message(STATUS "skipping cudnn tagged ${name} because USE_CUDNN is not set to true")
                 continue()
             endif()
         else()
@@ -291,142 +316,141 @@ else ()
     set(LIB_SUF so)
 endif ()
 if (WITH_TESTS)
-function(new_test descriptor)
-    parse_descriptor(${descriptor})
-    set(generator_target test_${id}_fct_generator)
-    set_obj(${PROJECT_BUILD}/generated_fct_test_${id}.o)
-    set(test_name test_${id})
-    build_g(${generator_target} tests/test_${id}.cpp "${obj}")
-    build_w(${test_name} "${obj}" tests/wrapper_test_${id}.cpp tests/wrapper_test_${id}.h)
-    add_test(NAME ${id}_build COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${test_name})
-    if (NOT ${is_mpi})
-        add_test(NAME ${id} COMMAND ${test_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    elseif (${USE_MPI}) # This is an MPI test (sanity check that we want to use MPI though)
-        # configure the options so files are copied on the fly as necessary.
-        add_test(NAME ${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe --wdir /tmp/ --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${test_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    endif()
-    set_tests_properties(${id} PROPERTIES DEPENDS ${id}_build)
-endfunction()
+    function(new_test descriptor)
+        parse_descriptor(${descriptor})
+        set(generator_target test_${id}_fct_generator)
+        set_obj(${PROJECT_BUILD}/generated_fct_test_${id}.o)
+        set(test_name test_${id})
+        build_g(${generator_target} tests/test_${id}.cpp "${obj}")
+        build_w(${test_name} "${obj}" tests/wrapper_test_${id}.cpp tests/wrapper_test_${id}.h)
+        add_test(NAME ${id}_build COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${test_name})
+        if (NOT ${is_mpi})
+            add_test(NAME ${id} COMMAND ${test_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        elseif (${USE_MPI}) # This is an MPI test (sanity check that we want to use MPI though)
+            # configure the options so files are copied on the fly as necessary.
+            add_test(NAME ${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe --wdir /tmp/ --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${test_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        endif()
+        set_tests_properties(${id} PROPERTIES DEPENDS ${id}_build)
+    endfunction()
 
-build_g(test_global tests/test_global.cpp "")
-add_test(NAME global_build COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target test_global)
-add_test(NAME global COMMAND test_global WORKING_DIRECTORY ${PROJECT_DIR})
-set_tests_properties(global PROPERTIES DEPENDS global_build)
-foreach(t ${TIRAMISU_TESTS})
-    new_test(${t})
-endforeach()
+    build_g(test_global tests/test_global.cpp "")
+    add_test(NAME global_build COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target test_global)
+    add_test(NAME global COMMAND test_global WORKING_DIRECTORY ${PROJECT_DIR})
+    set_tests_properties(global PROPERTIES DEPENDS global_build)
+    foreach(t ${TIRAMISU_TESTS})
+        new_test(${t})
+    endforeach()
 endif() #WITH_TESTS
 
 if (WITH_BENCHMARKS)
-add_custom_target(benchmarks)
+    add_custom_target(benchmarks)
 
-function(new_benchmark descriptor)
-    parse_descriptor(${descriptor})
-    set(tiramisu_generator_target bench_tiramisu_${id}_generator)
-    set(halide_generator_target   bench_halide_${id}_generator)
-    set_obj("${PROJECT_BUILD}/generated_fct_${id}.o")
-    set(generated_obj_halide   ${PROJECT_BUILD}/generated_fct_${id}_ref.o)
-    set(bench_name bench_${id})
-    build_g(${tiramisu_generator_target} benchmarks/halide/${id}_tiramisu.cpp "${obj}")
-    build_halide_g(${halide_generator_target} benchmarks/halide/${id}_ref.cpp ${generated_obj_halide})
-    build_w(${bench_name} "${obj};${generated_obj_halide}" benchmarks/halide/wrapper_${id}.cpp benchmarks/halide/wrapper_${id}.h)
-    if (NOT ${is_mpi})
-        add_custom_target(run_benchmark_${id} COMMAND ${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
-        add_custom_command(TARGET benchmarks COMMAND ${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    elseif (${USE_MPI})
-        # configure the options so files are copied on the fly as necessary.
-        add_custom_target(run_benchmark_${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe -wdir ${PROJECT_DIR} --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    endif()
-    add_dependencies(run_benchmark_${id} ${bench_name})
-endfunction()
+    function(new_benchmark descriptor)
+        parse_descriptor(${descriptor})
+        set(tiramisu_generator_target bench_tiramisu_${id}_generator)
+        set(halide_generator_target   bench_halide_${id}_generator)
+        set_obj("${PROJECT_BUILD}/generated_fct_${id}.o")
+        set(generated_obj_halide   ${PROJECT_BUILD}/generated_fct_${id}_ref.o)
+        set(bench_name bench_${id})
+        build_g(${tiramisu_generator_target} benchmarks/halide/${id}_tiramisu.cpp "${obj}")
+        build_halide_g(${halide_generator_target} benchmarks/halide/${id}_ref.cpp ${generated_obj_halide})
+        build_w(${bench_name} "${obj};${generated_obj_halide}" benchmarks/halide/wrapper_${id}.cpp benchmarks/halide/wrapper_${id}.h)
+        if (NOT ${is_mpi})
+            add_custom_target(run_benchmark_${id} COMMAND ${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
+            add_custom_command(TARGET benchmarks COMMAND ${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        elseif (${USE_MPI})
+            # configure the options so files are copied on the fly as necessary.
+            add_custom_target(run_benchmark_${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe -wdir ${PROJECT_DIR} --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        endif()
+        add_dependencies(run_benchmark_${id} ${bench_name})
+    endfunction()
 
-foreach(b ${TIRAMISU_BENCHMARKS})
-    new_benchmark(${b})
-endforeach()
+    foreach(b ${TIRAMISU_BENCHMARKS})
+        new_benchmark(${b})
+    endforeach()
 
 
-add_custom_target(dist_benchmarks)
+    add_custom_target(dist_benchmarks)
 
-function(new_dist_benchmark descriptor)
-    parse_descriptor(${descriptor})
-    set(tiramisu_generator_target dist_bench_tiramisu_${id}_generator)
-    set(ref_generator_target   dist_bench_ref_${id}_generator)
-    set_obj("${PROJECT_BUILD}/generated_fct_${id}.o")
-    set(generated_obj_ref   ${PROJECT_BUILD}/generated_fct_${id}_ref.o)
-    set(bench_name bench_${id})
-    build_g(${tiramisu_generator_target} benchmarks/automatic_comm/${id}_tiramisu.cpp "${obj}")
-    build_g(${ref_generator_target} benchmarks/automatic_comm/${id}_ref.cpp ${generated_obj_ref})
-    build_w(${bench_name} "${obj};${generated_obj_ref}" benchmarks/automatic_comm/wrapper_${id}.cpp benchmarks/automatic_comm/wrapper_${id}.h)
-    if (NOT ${is_mpi})
-        add_custom_target(run_dist_benchmark_${id} COMMAND ${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
-        add_custom_command(TARGET dist_benchmarks COMMAND ${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    elseif (${USE_MPI})
-        # configure the options so files are copied on the fly as necessary.
-        add_custom_target(run_dist_benchmark_${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe -wdir ${PROJECT_DIR} --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    endif()
-    add_dependencies(run_dist_benchmark_${id} ${bench_name})
-endfunction()
+    function(new_dist_benchmark descriptor)
+        parse_descriptor(${descriptor})
+        set(tiramisu_generator_target dist_bench_tiramisu_${id}_generator)
+        set(ref_generator_target   dist_bench_ref_${id}_generator)
+        set_obj("${PROJECT_BUILD}/generated_fct_${id}.o")
+        set(generated_obj_ref   ${PROJECT_BUILD}/generated_fct_${id}_ref.o)
+        set(bench_name bench_${id})
+        build_g(${tiramisu_generator_target} benchmarks/automatic_comm/${id}_tiramisu.cpp "${obj}")
+        build_g(${ref_generator_target} benchmarks/automatic_comm/${id}_ref.cpp ${generated_obj_ref})
+        build_w(${bench_name} "${obj};${generated_obj_ref}" benchmarks/automatic_comm/wrapper_${id}.cpp benchmarks/automatic_comm/wrapper_${id}.h)
+        if (NOT ${is_mpi})
+            add_custom_target(run_dist_benchmark_${id} COMMAND ${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
+            add_custom_command(TARGET dist_benchmarks COMMAND ${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        elseif (${USE_MPI})
+            # configure the options so files are copied on the fly as necessary.
+            add_custom_target(run_dist_benchmark_${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe -wdir ${PROJECT_DIR} --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${bench_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        endif()
+        add_dependencies(run_dist_benchmark_${id} ${bench_name})
+    endfunction()
 
-foreach(b ${TIRAMISU_DIST_BENCHMARKS})
-    new_dist_benchmark(${b})
-endforeach()
+    foreach(b ${TIRAMISU_DIST_BENCHMARKS})
+        new_dist_benchmark(${b})
+    endforeach()
 
-# Individual benchmarks are moved to benchmarks/CMakeLists.txt to reduce clutter
-add_subdirectory(benchmarks)
+    # Individual benchmarks are moved to benchmarks/CMakeLists.txt to reduce clutter
+    add_subdirectory(benchmarks)
 
 endif() #WITH_BENCHMAKRS
 
 if (WITH_DOCS)
-add_custom_target(doc DEPENDS ${PROJECT_DIR}/utils/doc_generation/Doxyfile)
-add_custom_command(TARGET doc COMMAND doxygen utils/doc_generation/Doxyfile WORKING_DIRECTORY ${PROJECT_DIR})
+    add_custom_target(doc DEPENDS ${PROJECT_DIR}/utils/doc_generation/Doxyfile)
+    add_custom_command(TARGET doc COMMAND doxygen utils/doc_generation/Doxyfile WORKING_DIRECTORY ${PROJECT_DIR})
 endif() #WITH_DOCS
 
 if (WITH_TUTORIALS)
-add_custom_target(tutorials)
+    add_custom_target(tutorials)
 
 
-function(new_developers_tutorial descriptor)
-    parse_descriptor(${descriptor})
-    set(generator_target developers_tutorial_${id}_fct_generator)
-    set_obj("${PROJECT_BUILD}/generated_fct_developers_tutorial_${id}.o")
-    set(tutorial_name tutorial_developers_${id})
-    build_g(${generator_target} tutorials/developers/tutorial_${id}/tutorial_${id}.cpp "${obj}")
-    build_w(${tutorial_name} "${obj}" tutorials/developers/tutorial_${id}/wrapper_tutorial_${id}.cpp tutorials/developers/tutorial_${id}/wrapper_tutorial_${id}.h)
-    if (NOT ${is_mpi})
-        add_custom_target(run_developers_tutorial_${id} COMMAND ${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
-        add_custom_command(TARGET tutorials COMMAND ${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    elseif (${USE_MPI}) # This is an MPI test (sanity check that we want to use MPI though)
-        # configure the options so files are copied on the fly as necessary.
-        add_custom_target(run_developers_tutorial_${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe --wdir /tmp/ --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    endif()
-    add_dependencies(run_developers_tutorial_${id} ${tutorial_name})
-endfunction()
+    function(new_developers_tutorial descriptor)
+        parse_descriptor(${descriptor})
+        set(generator_target developers_tutorial_${id}_fct_generator)
+        set_obj("${PROJECT_BUILD}/generated_fct_developers_tutorial_${id}.o")
+        set(tutorial_name tutorial_developers_${id})
+        build_g(${generator_target} tutorials/developers/tutorial_${id}/tutorial_${id}.cpp "${obj}")
+        build_w(${tutorial_name} "${obj}" tutorials/developers/tutorial_${id}/wrapper_tutorial_${id}.cpp tutorials/developers/tutorial_${id}/wrapper_tutorial_${id}.h)
+        if (NOT ${is_mpi})
+            add_custom_target(run_developers_tutorial_${id} COMMAND ${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
+            add_custom_command(TARGET tutorials COMMAND ${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        elseif (${USE_MPI}) # This is an MPI test (sanity check that we want to use MPI though)
+            # configure the options so files are copied on the fly as necessary.
+            add_custom_target(run_developers_tutorial_${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe --wdir /tmp/ --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        endif()
+        add_dependencies(run_developers_tutorial_${id} ${tutorial_name})
+    endfunction()
 
-function(new_users_tutorial descriptor)
-    parse_descriptor(${descriptor})
-    set(generator_target users_tutorial_${id}_fct_generator)
-    set_obj("${PROJECT_BUILD}/generated_fct_users_tutorial_${id}.o")
-    set(tutorial_name tutorial_users_${id})
-    build_g(${generator_target} tutorials/users/tutorial_${id}/tutorial_${id}.cpp "${obj}")
-    build_w(${tutorial_name} "${obj}" tutorials/users/tutorial_${id}/wrapper_tutorial_${id}.cpp tutorials/users/tutorial_${id}/wrapper_tutorial_${id}.h)
-    if (NOT ${is_mpi})
-        add_custom_target(run_users_tutorial_${id} COMMAND ${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
-        add_custom_command(TARGET tutorials COMMAND ${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    elseif (${USE_MPI}) # This is an MPI test (sanity check that we want to use MPI though)
-        # configure the options so files are copied on the fly as necessary.
-        add_custom_target(run_users_tutorial_${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe --wdir /tmp/ --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
-    endif()
-    add_dependencies(run_users_tutorial_${id} ${tutorial_name})
-endfunction()
+    function(new_users_tutorial descriptor)
+        parse_descriptor(${descriptor})
+        set(generator_target users_tutorial_${id}_fct_generator)
+        set_obj("${PROJECT_BUILD}/generated_fct_users_tutorial_${id}.o")
+        set(tutorial_name tutorial_users_${id})
+        build_g(${generator_target} tutorials/users/tutorial_${id}/tutorial_${id}.cpp "${obj}")
+        build_w(${tutorial_name} "${obj}" tutorials/users/tutorial_${id}/wrapper_tutorial_${id}.cpp tutorials/users/tutorial_${id}/wrapper_tutorial_${id}.h)
+        if (NOT ${is_mpi})
+            add_custom_target(run_users_tutorial_${id} COMMAND ${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
+            add_custom_command(TARGET tutorials COMMAND ${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        elseif (${USE_MPI}) # This is an MPI test (sanity check that we want to use MPI though)
+            # configure the options so files are copied on the fly as necessary.
+            add_custom_target(run_users_tutorial_${id} COMMAND ${MPI_BUILD_DIR}/bin/mpirun -x LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/tmp/ -np ${NUM_MPI_RANKS} -host ${MPI_NODES} --map-by node --oversubscribe --wdir /tmp/ --preload-files ${PROJECT_BUILD}/libtiramisu.${LIB_SUF},${PROJECT_DIR}/3rdParty/isl/.libs/libisl.${LIB_SUF} --preload-binary ${PROJECT_BUILD}/${tutorial_name} WORKING_DIRECTORY ${PROJECT_DIR})
+        endif()
+        add_dependencies(run_users_tutorial_${id} ${tutorial_name})
+    endfunction()
 
 
 
-   foreach(t ${TIRAMISU_DEVELOPERS_TUTORIALS})
-   	     new_developers_tutorial(${t})
-   endforeach()
-   foreach(t ${TIRAMISU_USERS_TUTORIALS})
-   	      new_users_tutorial(${t})
-   endforeach()
+    foreach(t ${TIRAMISU_DEVELOPERS_TUTORIALS})
+        new_developers_tutorial(${t})
+    endforeach()
+    foreach(t ${TIRAMISU_USERS_TUTORIALS})
+        new_users_tutorial(${t})
+    endforeach()
 endif() #WITH_TUTORIALS
-
 

--- a/build-install.sh
+++ b/build-install.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+# Function to print error and exit
+error_exit() {
+    echo "Error: $1"
+    exit 1
+}
+
+# Default value for TIRAMISU_INSTALL_DIR
+TIRAMISU_INSTALL_DIR=""
+
+# Parse command-line options
+while getopts "o:" opt; do
+    case "$opt" in
+        o) TIRAMISU_INSTALL_DIR="$OPTARG" ;;
+        *) error_exit "Invalid option: -$OPTARG" ;;
+    esac
+done
+
+# Set default TIRAMISU_INSTALL_DIR if not provided
+if [ -z "$TIRAMISU_INSTALL_DIR" ]; then
+    TIRAMISU_INSTALL_DIR="$PWD/install"
+fi
+
+# Detect the Linux distribution by checking package manager
+detect_distro() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+
+        if command -v apt &> /dev/null; then
+            DISTRO="ubuntu"  # Ubuntu/Debian based
+        elif command -v pacman &> /dev/null; then
+            DISTRO="arch"    # Arch-based
+        elif command -v dnf &> /dev/null; then
+            DISTRO="fedora"  # Fedora-based
+        else
+            error_exit "Unsupported distribution: $ID"
+        fi
+    else
+        error_exit "Unable to detect distribution."
+    fi
+}
+
+# Install dependencies based on the detected distribution
+install_dependencies() {
+    echo "Installing dependencies for $DISTRO..."
+    case "$DISTRO" in
+        ubuntu)
+            sudo apt install -y cmake libisl-dev zlib1g-dev || error_exit "Failed to install dependencies"
+            ;;
+        arch)
+            sudo pacman -Sy --noconfirm cmake isl zlib || error_exit "Failed to install dependencies"
+            ;;
+        fedora)
+            sudo dnf install -y cmake isl zlib-devel || error_exit "Failed to install dependencies"
+            ;;
+    esac
+    echo "Dependencies installed successfully."
+}
+
+# Download and extract Halide binaries
+download_halide() {
+    link="https://github.com/halide/Halide/releases/download/v14.0.0/Halide-14.0.0-x86-64-linux-6b9ed2afd1d6d0badf04986602c943e287d44e46.tar.gz"
+    filename="Halide-14.0.0-x86-64-linux.tar.gz"
+
+    echo "Downloading Halide binaries..."
+    mkdir -p 3rdParty/Halide-bin || error_exit "Failed to create directory for Halide binaries"
+    cd 3rdParty/Halide-bin || error_exit "Failed to enter Halide-bin directory"
+
+    if [ ! -f $filename ]; then
+        wget $link -O $filename || error_exit "Failed to download Halide binaries"
+    fi
+
+    # Clean up existing directories if they exist
+    if [ -d "bin" ] || [ -d "include" ] || [ -d "lib" ] || [ -d "share" ]; then
+        echo "Cleaning up existing directories..."
+        rm -rf bin include lib share || error_exit "Failed to clean up existing directories"
+    fi
+
+    echo "Extracting Halide binaries..."
+    tar -xzf $filename || error_exit "Failed to extract Halide binaries"
+
+    echo "Moving Halide files to desired structure..."
+    mv Halide-14.0.0-x86-64-linux/* . || error_exit "Failed to move Halide files"
+    rm -rf Halide-14.0.0-x86-64-linux || error_exit "Failed to clean up extracted folder"
+
+    cd ../../ || error_exit "Failed to return to root directory"
+    echo "Halide binaries downloaded, extracted, and reorganized successfully."
+}
+
+# Set environment variables
+set_environment() {
+    export TIRAMISU_ROOT="$PWD"
+    export LD_LIBRARY_PATH=${TIRAMISU_ROOT}/3rdParty/Halide-bin/lib:$LD_LIBRARY_PATH
+    export CMAKE_PREFIX_PATH=${TIRAMISU_ROOT}/3rdParty/Halide-bin/:$CMAKE_PREFIX_PATH
+    echo "Environment variables set."
+}
+
+# Save environment variables to .bashrc and .zshrc
+save_environment_variables() {
+    local RC_FILES=("$HOME/.bashrc" "$HOME/.zshrc")
+
+    for rc_file in "${RC_FILES[@]}"; do
+        if [ -f "$rc_file" ]; then
+            echo "Saving environment variables to $rc_file..."
+
+            # Add LD_LIBRARY_PATH if not already set
+            if ! grep -q "LD_LIBRARY_PATH=.*${TIRAMISU_ROOT}/3rdParty/Halide-bin/lib" "$rc_file"; then
+                echo "export LD_LIBRARY_PATH=${TIRAMISU_ROOT}/3rdParty/Halide-bin/lib:\$LD_LIBRARY_PATH" >> "$rc_file"
+            fi
+
+            # Add CMAKE_PREFIX_PATH if not already set
+            if ! grep -q "CMAKE_PREFIX_PATH=.*${TIRAMISU_ROOT}/3rdParty/Halide-bin/" "$rc_file"; then
+                echo "export CMAKE_PREFIX_PATH=${TIRAMISU_ROOT}/3rdParty/Halide-bin/:\$CMAKE_PREFIX_PATH" >> "$rc_file"
+            fi
+
+            # Add TIRAMISU_ROOT if not already set
+            if ! grep -q "TIRAMISU_ROOT=.*${TIRAMISU_ROOT}" "$rc_file"; then
+                echo "export TIRAMISU_ROOT=${TIRAMISU_ROOT}" >> "$rc_file"
+            fi
+
+        fi
+    	echo "Environment variables saved to $rc_file."
+    done
+}
+
+# Build Tiramisu
+build_tiramisu() {
+    echo "Building Tiramisu..."
+
+    # Clean up the build and install directories just in case, to prevent some CMake errors
+    rm -rf build
+
+    cmake . -B build -DBIN_HALIDE_INSTALL_METHOD=1 -DCMAKE_INSTALL_PREFIX=$TIRAMISU_INSTALL_DIR -DWITH_PYTHON_BINDINGS=false || error_exit "CMake configuration failed"
+    cmake --build build --config Release -- -j$(nproc) tiramisu tiramisu_auto_scheduler || error_exit "Build failed"
+
+    mkdir -p $TIRAMISU_INSTALL_DIR
+    rm -rf install/*  # clean up if it existed before already
+    cmake --install build || error_exit "Installation failed"
+    echo "Tiramisu built and installed successfully at $TIRAMISU_INSTALL_DIR."
+}
+
+# Main script execution
+detect_distro
+install_dependencies
+download_halide
+set_environment
+build_tiramisu
+save_environment_variables
+
+echo ""
+echo ""
+echo "Tiramisu build and install process completed successfully."


### PR DESCRIPTION
This PR introduces a faster installation method for building Tiramisu by utilizing precompiled Halide binaries and linking them statically during the build process. This new method drastically reduces the installation time by skipping the lengthy process of building LLVM from scratch. 

Additionally, ISL is now installed using the system package manager (instead of being manually built), further speeding up the setup.

#### Key Changes:
1. **Halide Binaries:**
   - Precompiled Halide binaries are downloaded from the [official Halide repository](https://github.com/halide/Halide/releases) and linked statically to Tiramisu during the build process. This eliminates the need to build LLVM, significantly reducing the build time.

2. **ISL Installation:**
   - ISL is now installed via the system's package manager, leveraging the available packages (`libisl-dev` for Ubuntu, `isl` for Arch, and `isl-devel` for Fedora).
   - No need to manually build ISL, simplifying the overall installation process.

3. **Script Improvements:**
   - A Bash script has been added to automate the entire build process on Linux-based systems (Ubuntu, Arch, Fedora). It handles the installation of dependencies, downloading Halide binaries, and building Tiramisu.
   - **Linux support**: This method currently supports Linux distributions only. However, the script can be extended to work on macOS if someone can test it in the future.


#### Notes:
- This method is currently tested and working on Linux distributions (Ubuntu-based, Arch-based, Fedora-based). MacOS support can be added in the future with proper testing.
  