### PR TITLE
Document new installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ void generate_code()
     //   for (j=0; j<100; j++)
     //     C(i,j) = 0;
     computation C({i,j}, 0);
-    
+
     // Specify optimizations
     C.parallelize(i);
     C.vectorize(j, 4);
-    
+
     buffer b_C("b_C", {100, 100}, p_int32, a_output);
     C.store_in(&b_C);
 
@@ -42,60 +42,6 @@ void generate_code()
 }
 ```
 
-## Installing Tiramisu (Linux only)
-This section describes how to install Tiramisu on Linux distributions based on Debian, Ubuntu, Arch and Fedora.
-
-#### 1. Clone the repo and checkout to `merge_attempt` branch
-```bash
-git clone https://github.com/Tiramisu-Compiler/tiramisu
-cd tiramisu
-git checkout merge_attempt
-```
-
-#### 2. Run the installation script
-```bash
-bash build-install.sh -o <installation_directory>
-```
-
-This script will automatically download the dependencies and build Tiramisu.
-
-
-##### 2.1. Script arguments:
-`-o <install_directory>`:
-- **Description**: Specifies the directory where Tiramisu will be installed.
-- **Default**: If not provided, the script will use the default install directory `$PWD/install`.
-- **Usage**: `./build-install.sh -o /path/to/install/dir`
-    - Example: `./build-install.sh -o /home/user/tiramisu_install`
-
-
-##### 2.2. Script side effects:
-The script saves the following environment variables to the user's `.bashrc` and `.zshrc` files:
-
-###### 1. `TIRAMISU_ROOT`
-- **Description**: Specifies the root directory of the Tiramisu project (the current working directory when the script is executed).
-- **Value**: The current directory where the script is executed (`$PWD`).
-- **Purpose**: Used to reference the Tiramisu project directory for build and configuration purposes.
-
-###### 2. `LD_LIBRARY_PATH`
-- **Description**: Specifies the directory paths where dynamic libraries are searched during execution.
-- **Value**: `${TIRAMISU_ROOT}/3rdParty/Halide-bin/lib:$LD_LIBRARY_PATH`
-- **Purpose**: Adds the path to Halide binaries to ensure that any executables linked against Halide can find the necessary libraries.
-
-###### 3. `CMAKE_PREFIX_PATH`
-- **Description**: Provides the search paths for CMake to locate installed packages.
-- **Value**: `${TIRAMISU_ROOT}/3rdParty/Halide-bin/:$CMAKE_PREFIX_PATH`
-- **Purpose**: Tells CMake where to find the Halide binaries during the build process.
-
-###### Example of what will be added to `.bashrc` and `.zshrc`:
-
-```bash
-# Set up environment variables for Tiramisu
-export TIRAMISU_ROOT=/path/to/tiramisu
-export LD_LIBRARY_PATH=/path/to/tiramisu/3rdParty/Halide-bin/lib:$LD_LIBRARY_PATH
-export CMAKE_PREFIX_PATH=/path/to/tiramisu/3rdParty/Halide-bin/:$CMAKE_PREFIX_PATH
-```
-
-These environment variables ensure that the Tiramisu project has access to the necessary Halide libraries and paths for successful builds and runtime execution.
 
 
 
@@ -110,7 +56,7 @@ This section provides a description of how to build Tiramisu.  The installation 
 2) [Autoconf](https://www.gnu.org/software/autoconf/) and [libtool](https://www.gnu.org/software/libtool/).
 
 3) [Ninja](https://ninja-build.org/).
-  
+
 ###### Optional
 1) [OpenMPI](https://www.open-mpi.org/) and [OpenSSh](https://www.openssh.com/): if you want to generate and run distributed code (MPI).
 2) [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit): if you want to generate and run CUDA code.
@@ -122,7 +68,7 @@ This section provides a description of how to build Tiramisu.  The installation 
 
 There are 3 ways to build Tiramisu:
 1) From [spack](https://packages.spack.io/package.html?name=tiramisu), which will build everything from source for you.
-2) From source, but using system package managers for dependencies. 
+2) From source, but using system package managers for dependencies.
 3) Purely from source with our install script.
 
 The last two only differ only in how they setup the dependenies.
@@ -158,7 +104,7 @@ If any of these ask you to update your path, do so. For example, using the follo
 brew info isl
 ISL_INCLUDE_DIRECTORY=..
 ISL_LIB_DIRECTORY=..
-```		
+```
 
 ###### Install the dependencies using Apt
 
@@ -174,16 +120,16 @@ sudo apt-get install llvm14-*
 sudo apt-get install halide
 sudo apt-get install libisl-dev
 ```
-		
-		
+
+
  Using the following command, you can find the isl include and library directories:
 ```bash
 dpkg -L libisl-dev
 ISL_INCLUDE_DIRECTORY=..
 ISL_LIB_DIRECTORY=..
 ```
-		
-##### Building Tiramisu with cmake 
+
+##### Building Tiramisu with cmake
 
 1) Get Tiramisu
 ```bash
@@ -199,7 +145,7 @@ mkdir build
 ```bash
 cmake . -B build -DISL_LIB_DIRECTORY=$ISL_LIB_DIRECTORY -DISL_INCLUDE_DIRECTORY=$ISL_INCLUDE_DIRECTORY -DPython3_EXECUTABLE=`which python3`
 ```
-		
+
 If you want to install, add `CMAKE_INSTALL_PREFIX`. If you are installing the python bindings, add `Tiramisu_INSTALL_PYTHONDIR` to tell Tiramisu where to place a python package. You will need add these install locations to the relevant path variables such as `PYTHONPATH` and `LD_LIBRARY_PATH`.
 
 4) Build:
@@ -208,7 +154,7 @@ cmake --build build
 ```
 
 You can also install if you want via `cmake --install`.
-		
+
 
 #### Method 3: Build from source, but install dependencies using our script
 
@@ -233,8 +179,8 @@ cd tiramisu
     - To use the GPU backend, set `USE_GPU` to `TRUE`. If the CUDA library is not found automatically while building Tiramisu, the user will be prompt to provide the path to the CUDA library.
     - To use the distributed backend, set `USE_MPI` to `TRUE`. If the MPI library is not found automatically, set the following variables: MPI_INCLUDE_DIR, MPI_LIB_DIR, and MPI_LIB_FLAGS.
     - To build the autoscheduler module, set `USE_AUTO_SCHEDULER` to `TRUE`.
-	
-4) Add Halide's cmake to the `CMAKE_PREFIX_PATH`: 
+
+4) Add Halide's cmake to the `CMAKE_PREFIX_PATH`:
 ```bash
 export CMAKE_PREFIX_PATH=$TIRAMISU_ROOT_DIR/3rdParty/Halide/install/:$CMAKE_PREFIX_PATH
 ```
@@ -245,11 +191,71 @@ cd build
 cmake ..
 cmake --build .
 ```
-        
+
 6) If you want to build the autoscheduler module, set `USE_AUTO_SCHEDULER` to `TRUE` in `configure.cmake`, and after building Tiramisu :
 ```bash
 make tiramisu_auto_scheduler
 ```
+
+
+#### Method 4: Installing Tiramisu with script (Linux only)
+This section describes how to install Tiramisu on Linux distributions based on Debian, Ubuntu, Arch and Fedora.
+
+Note that this is the fastest installation method, as it doesn't require building the large dependencies (LLVM and Halide) but downloads their binaries and links them directly.
+
+##### 1. Clone the repo and checkout to `merge_attempt` branch
+```bash
+git clone https://github.com/Tiramisu-Compiler/tiramisu
+cd tiramisu
+git checkout merge_attempt
+```
+
+##### 2. Run the installation script
+```bash
+bash build-install.sh -o <installation_directory>
+```
+
+This script will automatically download the dependencies and build Tiramisu.
+
+
+###### 2.1. Script arguments:
+`-o <install_directory>`:
+- **Description**: Specifies the directory where Tiramisu will be installed.
+- **Default**: If not provided, the script will use the default install directory `$PWD/install`.
+- **Usage**: `./build-install.sh -o /path/to/install/dir`
+    - Example: `./build-install.sh -o /home/user/tiramisu_install`
+
+
+###### 2.2. Script side effects:
+The script saves the following environment variables to the user's `.bashrc` and `.zshrc` files:
+
+- `TIRAMISU_ROOT`
+	- **Description**: Specifies the root directory of the Tiramisu project (the current working directory when the script is executed).
+	- **Value**: The current directory where the script is executed (`$PWD`).
+	- **Purpose**: Used to reference the Tiramisu project directory for build and configuration purposes.
+
+- `LD_LIBRARY_PATH`
+	- **Description**: Specifies the directory paths where dynamic libraries are searched during execution.
+	- **Value**: `${TIRAMISU_ROOT}/3rdParty/Halide-bin/lib:$LD_LIBRARY_PATH`
+	- **Purpose**: Adds the path to Halide binaries to ensure that any executables linked against Halide can find the necessary libraries.
+
+- `CMAKE_PREFIX_PATH`
+	- **Description**: Provides the search paths for CMake to locate installed packages.
+	- **Value**: `${TIRAMISU_ROOT}/3rdParty/Halide-bin/:$CMAKE_PREFIX_PATH`
+	- **Purpose**: Tells CMake where to find the Halide binaries during the build process.
+
+##### 2.3. Example of what will be added to `.bashrc` and `.zshrc`:
+
+```bash
+# Set up environment variables for Tiramisu
+export TIRAMISU_ROOT=/path/to/tiramisu
+export LD_LIBRARY_PATH=/path/to/tiramisu/3rdParty/Halide-bin/lib:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=/path/to/tiramisu/3rdParty/Halide-bin/:$CMAKE_PREFIX_PATH
+```
+
+These environment variables ensure that the Tiramisu project has access to the necessary Halide libraries and paths for successful builds and runtime execution.
+
+
 ## Old Tiramisu on a Virtual Machine
 Users can use the Tiramisu [virtual machine disk image](http://groups.csail.mit.edu/commit/software/TiramisuVM.zip).  The image is created using virtual box (5.2.12) and has Tiramisu already pre-compiled and ready for use. It was compiled using the same instructions in this README file.
 
@@ -258,7 +264,7 @@ Once you download the image, unzip it and use virtual box to open the file 'Tira
 Once the virtual machine has started, open a terminal, then go to the Tiramisu directory
 
     cd /home/b/tiramisu/
-    
+
 If asked for a username/password
 
     Username:b
@@ -281,7 +287,7 @@ To run all the tests, assuming you are in the build/ directory
 or
 
     ctest
-    
+
 To run only one test (test_01 for example)
 
     ctest -R 01

--- a/README.md
+++ b/README.md
@@ -42,6 +42,63 @@ void generate_code()
 }
 ```
 
+## Installing Tiramisu (Linux only)
+This section describes how to install Tiramisu on Linux distributions based on Debian, Ubuntu, Arch and Fedora.
+
+#### 1. Clone the repo and checkout to `merge_attempt` branch
+```bash
+git clone https://github.com/Tiramisu-Compiler/tiramisu
+cd tiramisu
+git checkout merge_attempt
+```
+
+#### 2. Run the installation script
+```bash
+bash build-install.sh -o <installation_directory>
+```
+
+This script will automatically download the dependencies and build Tiramisu.
+
+
+##### 2.1. Script arguments:
+`-o <install_directory>`:
+- **Description**: Specifies the directory where Tiramisu will be installed.
+- **Default**: If not provided, the script will use the default install directory `$PWD/install`.
+- **Usage**: `./build-install.sh -o /path/to/install/dir`
+    - Example: `./build-install.sh -o /home/user/tiramisu_install`
+
+
+##### 2.2. Script side effects:
+The script saves the following environment variables to the user's `.bashrc` and `.zshrc` files:
+
+###### 1. `TIRAMISU_ROOT`
+- **Description**: Specifies the root directory of the Tiramisu project (the current working directory when the script is executed).
+- **Value**: The current directory where the script is executed (`$PWD`).
+- **Purpose**: Used to reference the Tiramisu project directory for build and configuration purposes.
+
+###### 2. `LD_LIBRARY_PATH`
+- **Description**: Specifies the directory paths where dynamic libraries are searched during execution.
+- **Value**: `${TIRAMISU_ROOT}/3rdParty/Halide-bin/lib:$LD_LIBRARY_PATH`
+- **Purpose**: Adds the path to Halide binaries to ensure that any executables linked against Halide can find the necessary libraries.
+
+###### 3. `CMAKE_PREFIX_PATH`
+- **Description**: Provides the search paths for CMake to locate installed packages.
+- **Value**: `${TIRAMISU_ROOT}/3rdParty/Halide-bin/:$CMAKE_PREFIX_PATH`
+- **Purpose**: Tells CMake where to find the Halide binaries during the build process.
+
+###### Example of what will be added to `.bashrc` and `.zshrc`:
+
+```bash
+# Set up environment variables for Tiramisu
+export TIRAMISU_ROOT=/path/to/tiramisu
+export LD_LIBRARY_PATH=/path/to/tiramisu/3rdParty/Halide-bin/lib:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=/path/to/tiramisu/3rdParty/Halide-bin/:$CMAKE_PREFIX_PATH
+```
+
+These environment variables ensure that the Tiramisu project has access to the necessary Halide libraries and paths for successful builds and runtime execution.
+
+
+
 ## Building Tiramisu from Sources
 
 This section provides a description of how to build Tiramisu.  The installation instructions below have been tested on Linux Ubuntu (18.04) and MacOS (13.0.1) but should work on other Linux and MacOS versions.


### PR DESCRIPTION
This pull request includes new installation instructions for Tiramisu on Linux distributions. The changes add detailed steps for cloning the repository, running the installation script, and setting up necessary environment variables.

### Installation Instructions:

* Added a new section "Installing Tiramisu (Linux only)" to the `README.md` file.
* Included steps to clone the repository and checkout to the `merge_attempt` branch.
* Provided commands to run the installation script with an optional argument to specify the installation directory.
* Described the script's side effects, including setting up environment variables `TIRAMISU_ROOT`, `LD_LIBRARY_PATH`, and `CMAKE_PREFIX_PATH` in the user's `.bashrc` and `.zshrc` files.