### PR TITLE
Document new installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,65 @@ cmake --build .
 ```bash
 make tiramisu_auto_scheduler
 ```
+
+#### Method 4: Installing Tiramisu with script (Linux only)
+This section describes how to install Tiramisu on Linux distributions based on Debian, Ubuntu, Arch and Fedora.
+
+Note that this is the fastest installation method, as it doesn't require building the large dependencies (LLVM and Halide) but downloads their binaries and links them directly.
+
+##### 1. Clone the repo and checkout to `merge_attempt` branch
+```bash
+git clone https://github.com/Tiramisu-Compiler/tiramisu
+cd tiramisu
+git checkout merge_attempt
+```
+
+##### 2. Run the installation script
+```bash
+bash build-install.sh -o <installation_directory>
+```
+
+This script will automatically download the dependencies and build Tiramisu.
+
+
+###### 2.1. Script arguments:
+`-o <install_directory>`:
+- **Description**: Specifies the directory where Tiramisu will be installed.
+- **Default**: If not provided, the script will use the default install directory `$PWD/install`.
+- **Usage**: `./build-install.sh -o /path/to/install/dir`
+    - Example: `./build-install.sh -o /home/user/tiramisu_install`
+
+
+###### 2.2. Script side effects:
+The script saves the following environment variables to the user's `.bashrc` and `.zshrc` files:
+
+- `TIRAMISU_ROOT`
+	- **Description**: Specifies the root directory of the Tiramisu project (the current working directory when the script is executed).
+	- **Value**: The current directory where the script is executed (`$PWD`).
+	- **Purpose**: Used to reference the Tiramisu project directory for build and configuration purposes.
+
+- `LD_LIBRARY_PATH`
+	- **Description**: Specifies the directory paths where dynamic libraries are searched during execution.
+	- **Value**: `${TIRAMISU_ROOT}/3rdParty/Halide-bin/lib:$LD_LIBRARY_PATH`
+	- **Purpose**: Adds the path to Halide binaries to ensure that any executables linked against Halide can find the necessary libraries.
+
+- `CMAKE_PREFIX_PATH`
+	- **Description**: Provides the search paths for CMake to locate installed packages.
+	- **Value**: `${TIRAMISU_ROOT}/3rdParty/Halide-bin/:$CMAKE_PREFIX_PATH`
+	- **Purpose**: Tells CMake where to find the Halide binaries during the build process.
+
+##### 2.3. Example of what will be added to `.bashrc` and `.zshrc`:
+
+```bash
+# Set up environment variables for Tiramisu
+export TIRAMISU_ROOT=/path/to/tiramisu
+export LD_LIBRARY_PATH=/path/to/tiramisu/3rdParty/Halide-bin/lib:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=/path/to/tiramisu/3rdParty/Halide-bin/:$CMAKE_PREFIX_PATH
+```
+
+These environment variables ensure that the Tiramisu project has access to the necessary Halide libraries and paths for successful builds and runtime execution.
+
+
 ## Old Tiramisu on a Virtual Machine
 Users can use the Tiramisu [virtual machine disk image](http://groups.csail.mit.edu/commit/software/TiramisuVM.zip).  The image is created using virtual box (5.2.12) and has Tiramisu already pre-compiled and ready for use. It was compiled using the same instructions in this README file.
 


### PR DESCRIPTION
This pull request includes new installation instructions for Tiramisu on Linux distributions. The changes add detailed steps for cloning the repository, running the installation script, and setting up necessary environment variables.

### Installation Instructions:

* Added a new section "Installing Tiramisu (Linux only)" to the `README.md` file.
* Included steps to clone the repository and checkout to the `merge_attempt` branch.
* Provided commands to run the installation script with an optional argument to specify the installation directory.
* Described the script's side effects, including setting up environment variables `TIRAMISU_ROOT`, `LD_LIBRARY_PATH`, and `CMAKE_PREFIX_PATH` in the user's `.bashrc` and `.zshrc` files.